### PR TITLE
Changed status setting for no-scanjob pattern, simplified the scanjob map, embeded scan button into resource table's table actions

### DIFF
--- a/pkg/sbombastic-image-vulnerability-scanner/components/RegistryDetails.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/components/RegistryDetails.vue
@@ -5,7 +5,7 @@
         <div class="resource-header">
           <div class="resource-header-name-state">
             <span class="resource-header-name">
-              <RouterLink :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${ this.RESOURCE.REGISTRY }/`">{{ t('imageScanner.registries.title') }}:</RouterLink> 
+              <RouterLink :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${ this.RESOURCE.REGISTRY }/`">{{ t('imageScanner.registries.title') }}:</RouterLink>
               {{ $route.params.id }}
             </span>
             <RegisterStatusBadge :status="registryStatus" />
@@ -73,7 +73,7 @@
 
       await this.$store.dispatch('cluster/findAll', { type: RESOURCE.SCAN_JOB });
       let scanJobs = this.$store.getters['cluster/all'](RESOURCE.SCAN_JOB);
-      
+
       // filter scan jobs for the current registry
       scanJobs = scanJobs.filter((job) => {
         return job.spec.registry === registry.metadata.name;

--- a/pkg/sbombastic-image-vulnerability-scanner/components/common/RegisterStatusBadge.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/components/common/RegisterStatusBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="badge" :class="statusClass">
-    <div v-if="status" class="text">{{ t(`imageScanner.enum.status.${status.toLowerCase()}`) }}</div>
+    <div v-if="status" class="text" :class="statusClass">{{ t(`imageScanner.enum.status.${status.toLowerCase()}`) }}</div>
   </div>
 </template>
 
@@ -29,7 +29,7 @@
             case REGISTRY_STATUS.FAILED:
                 return "failed";
             default:
-                return "";
+                return "none";
         }
       }
     }
@@ -82,6 +82,9 @@
       font-style: normal;
       font-weight: 400;
       line-height: 19px;
+      &.none {
+        color: var(--muted);
+      }
     }
   }
 </style>

--- a/pkg/sbombastic-image-vulnerability-scanner/components/common/RegistryStatusUpdate.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/components/common/RegistryStatusUpdate.vue
@@ -1,11 +1,11 @@
 <template>
-    <div v-if="registryStatus.registry_name" class="registry-status-record">
-        <RouterLink class="registry-name" :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${ this.PAGE.REGISTRIES }/${ registryStatus.namespace }/${ registryStatus.registry_name }`">{{ registryStatus.registry_name }}</RouterLink>
+    <div v-if="registryStatus.registryName" class="registry-status-record">
+        <RouterLink class="registry-name" :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${ this.PAGE.REGISTRIES }/${ registryStatus.namespace }/${ registryStatus.registryName }`">{{ registryStatus.registryName }}</RouterLink>
         <div class="uri">{{ registryStatus.uri }}</div>
-        <div class="prev-status"><RegisterStatusBadge :status="registryStatus.prev_status"/></div>
+        <div class="prev-status"><RegisterStatusBadge :status="registryStatus.prevStatus"/></div>
         <div class="arrow"></div>
-        <div  class="curr-status"><RegisterStatusBadge :status="registryStatus.curr_status"/></div>
-        <div class="update-time">{{ `${updateTime(registryStatus.last_update_time)} ${t("imageScanner.general.ago")}`}}</div>
+        <div  class="curr-status"><RegisterStatusBadge :status="registryStatus.currStatus"/></div>
+        <div class="update-time">{{ `${updateTime(registryStatus.lastUpdateTime)}` }}</div>
     </div>
     <div v-else class="registry-status-record">
         <div class="no-data"></div>
@@ -38,7 +38,7 @@
     },
     methods: {
         updateTime(lastUpdateTime) {
-            return  elapsedTime(Date.now() / 1000 - new Date(lastUpdateTime).getTime() / 1000).label;
+            return  elapsedTime(Math.ceil(Date.now() / 1000) - Math.ceil((new Date(lastUpdateTime).getTime() / 1000))).label + ' ' + this.t("imageScanner.general.ago");
         }
     }
   }

--- a/pkg/sbombastic-image-vulnerability-scanner/config/sbombastic-image-vulnerability-scanner.ts
+++ b/pkg/sbombastic-image-vulnerability-scanner/config/sbombastic-image-vulnerability-scanner.ts
@@ -69,9 +69,9 @@ export function init($plugin: IPlugin, store: any) {
         PAGE.IMAGE_OVERVIEW,
         PAGE.VULNERABILITY_OVERVIEW,
         PAGE.VEX_MANAGEMENT,
-        "demo"
+        //"demo"
     ]);
 
-    basicType([RESOURCE.REGISTRY], 'Advanced');
+  basicType([RESOURCE.REGISTRY, PAGE.VEX_MANAGEMENT], 'Advanced');
 
 }

--- a/pkg/sbombastic-image-vulnerability-scanner/config/table-headers.ts
+++ b/pkg/sbombastic-image-vulnerability-scanner/config/table-headers.ts
@@ -36,16 +36,20 @@ export const REGISTRY_SCAN_TABLE = [
   {
     name: "status",
     labelKey: "imageScanner.registries.registrytable.header.status",
-    value: "scanjobs.0.status.statusResult.type",
+    value: "currStatus",
     formatter: "RegistryStatusCellBadge",
     sort: "status",
     width: 100,
   },
   {
-    name: "_progress",
+    name: "progress",
     labelKey: "imageScanner.registries.registrytable.header.progress",
-    value: "scanjobs.0.status.imagesCount",
-    getValue: (row: any) => row.scanjobs[0].status.imagesCount,
+    getValue: (row: any) => {
+      return {
+        progress: row.progress,
+        error: row.error,
+      }
+    },
     formatter: "ProgressCell",
     sort: "progress",
   },

--- a/pkg/sbombastic-image-vulnerability-scanner/formatters/PreviousScanCell.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/formatters/PreviousScanCell.vue
@@ -12,35 +12,26 @@ export default {
     }
   },
   methods: {
-    getStatusStyle(row) {
-      if (row && row.scanjobs[1] && row.scanjobs[1].status && row.scanjobs[1].status.statusResult && row.scanjobs[1].status.statusResult.type) {
-        return { color: 'var(--text-secondary)' };
-      } else {
-        return { color: 'var(--text-muted)' };
-      }
-    },
     getStatusText(row) {
-      if (row && row.scanjobs[1] && row.scanjobs[1].status && row.scanjobs[1].status.statusResult && row.scanjobs[1].status.statusResult.type) {
-        return this.t(`imageScanner.enum.status.${row.scanjobs[1].status.statusResult.type.toLowerCase()}`);
-      } else {
-        return this.t('imageScanner.enum.status.none');
-      }
+      return this.t(`imageScanner.enum.status.${row.prevStatus.toLowerCase()}`);
+    },
+    getStatusLabelClass(row) {
+      return row.prevStatus.toLowerCase();
+    },
+    getStatusDotClass(row) {
+      return `dot ${row.prevStatus.toLowerCase()}`;
     }
   }
 };
 </script>
 
 <template>
-    <div v-if="row && row.scanjobs[1] && row.scanjobs[1].status && row.scanjobs[1].status.statusResult && row.scanjobs[1].status.statusResult.type" class="previous-scan-cell">
-        <div class="dot" :class="row.scanjobs[1].status.statusResult.type.toLowerCase()"></div>
-        <div class="status" :style="getStatusStyle(row)">{{ getStatusText(row) }}</div>  
-        <div v-if="row.scanjobs[1].status.statusResult.progress">
-          <ProgressCell :status="row.scanjobs[1].status.statusResult" />
+    <div class="previous-scan-cell">
+        <div class="dot" :class="getStatusDotClass(row)"></div>
+        <div class="status" :class="getStatusLabelClass(row)">{{ getStatusText(row) }}</div>
+        <div v-if="row.prevProgress">
+          <ProgressCell :status="{ progress: row.prevProgress, error: row.error }" />
         </div>
-    </div>
-    <div v-else class="previous-scan-cell">
-      <div class="dot pending"></div>
-      <div class="status" style="color: var(--text-secondary)">{{ t('imageScanner.enum.status.pending') }}</div>  
     </div>
 </template>
 
@@ -53,6 +44,9 @@ export default {
         font-size: 14px;
         .status {
             font-size: 14px;
+            &.none {
+                color: var(--muted);
+            }
         }
         .dot {
             width: 8px;

--- a/pkg/sbombastic-image-vulnerability-scanner/formatters/ProgressCell.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/formatters/ProgressCell.vue
@@ -10,7 +10,7 @@ export default {
 </script>
 <template>
   <div class="progress-cell">
-    <span v-if="value.progress" class="progress-text">{{ value.progress }}% | <span v-if="value.errors">{{ value.errors }}</span></span>
+    <span v-if="value.progress" class="progress-text">{{ value.progress }}% | <span v-if="value.error">{{ value.error }}</span></span>
     <span v-else class="progress-text text-muted">n/a</span>
   </div>
 </template>

--- a/pkg/sbombastic-image-vulnerability-scanner/formatters/RegistryStatusCellBadge.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/formatters/RegistryStatusCellBadge.vue
@@ -14,5 +14,5 @@ export default {
 </script>
 
 <template>
-  <RegisterStatusBadge :status="value.toLowerCase() || 'pending'" />
+  <RegisterStatusBadge :status="value.toLowerCase()" />
 </template>

--- a/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
+++ b/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
@@ -7,6 +7,7 @@ imageScanner:
       addNew: Add new
       refresh: Refresh data
       startScan: Start scan
+      delete: Delete
     recentUpdatedRegistries:
       title: Latest status updates
     StatusDistribution:
@@ -60,8 +61,8 @@ imageScanner:
           imagesFound: Images found
           error: Error
     messages:
-      registryScanFailed: Registry scan failed
-      registryScanComplete: Registry scan complete
+      registryScanFailed: Registry scan failed to start
+      registryScanComplete: Registry scan is started successfully
   images:
     title: Images
     downloadReport: Download full report
@@ -117,6 +118,7 @@ imageScanner:
       inprogress: In progress
       complete: Complete
       failed: Failed
+      none: n/a
       enabled: Enabled
       disabled: Disabled
     prevScan:
@@ -128,6 +130,7 @@ imageScanner:
   general:
     refresh: Refresh data
     ago: ago
+    justNow: Just now
 
 typeLabel:
   sbombastic.rancher.io.registry: Registries configuration

--- a/pkg/sbombastic-image-vulnerability-scanner/list/sbombastic.rancher.io.registry.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/list/sbombastic.rancher.io.registry.vue
@@ -5,15 +5,6 @@
       <RecentUpdatedRegistries :registryStatusList="registryStatusList"/>
       <StatusDistribution :chartData="statusSummary"/>
     </div>
-    <button
-      mat-button
-      class="btn role-secondary"
-      style="margin-bottom: 12px;"
-      aria-label="Refresh data"
-      type="button"
-      @click="startScan()">
-      <em class="icon-refresh-ss"></em>{{ t('imageScanner.registries.button.startScan') }}
-    </button>
     <ResourceTable
       ref="table"
       :schema="schema"
@@ -21,7 +12,28 @@
       :rows="rows"
       :headers="headers"
       @selection="onSelectionChange"
-    />
+    >
+      <template #header-left>
+          <div class="bulk-actions">
+            <button
+              class="btn role-primary"
+              :disabled="!(selectedRows && selectedRows.length)"
+              @click="startScan()"
+            >
+              <i class="icon icon-play"></i>
+              {{ t('imageScanner.registries.button.startScan') || 'Enable' }}
+            </button>
+            <button
+              class="btn role-primary"
+              :disabled="!(selectedRows && selectedRows.length)"
+              @click="promptRemoveRegistry()"
+            >
+              <i class="icon icon-delete"></i>
+              {{ t('imageScanner.registries.button.delete') || 'Delete' }}
+            </button>
+          </div>
+      </template>
+    </ResourceTable>
   </div>
 </template>
 
@@ -39,6 +51,7 @@
   import { escapeHtml } from '@shell/utils/string';
   import day from 'dayjs';
   import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+  import { findBy } from '@shell/utils/array';
 
   export default {
     name: 'registries',
@@ -82,9 +95,10 @@
           complete: 0,
           failed: 0
         };
-        this.latestUpdateTime = null;
         
         let registriesCRD = this.$store.getters['cluster/all'](RESOURCE.REGISTRY);
+
+        //Fetch ScanJob CRD and sort by startTime DESC
         let scanJobCRD = this.$store.getters['cluster/all'](RESOURCE.SCAN_JOB).sort((a, b) => {
           if (!a.status || !a.status.startTime) {
             return 1;
@@ -97,13 +111,19 @@
 
         let scanJobMap = {};
         scanJobCRD.forEach((rec) => {
-          rec.status.statusResult = rec.status.conditions.filter(condition => {
+          rec.status.statusResult = rec.status?.conditions?.filter(condition => {
             return condition.status === "True";
           })[0] || {
             type: "Pending",
             lastUpdateTime: null,
           };
-          if (scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`]) {
+
+          // Set ScanJobe map with namespace/registry as key and up to 2 scan jobs as value
+          if (
+            scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`] &&
+            Array.isArray(scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`]) &&
+            scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`].length > 0 &&
+            scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`].length < 2) {
             scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`].push(rec);
           } else {
             scanJobMap[`${rec.metadata.namespace}/${rec.spec.registry}`] = [rec];
@@ -112,48 +132,68 @@
 
         this.rows = registriesCRD.map((rec) => {
           this.latestUpdateTime = new Date();
+          let scanjobs = scanJobMap[`${rec.metadata.namespace}/${rec.metadata.name}`] || [];
+          const status = scanjobs[0] ? scanjobs[0].status.statusResult.type.toLowerCase() || "pending" : "none";
+          const prevStatus = scanjobs[1] ? scanjobs[1].status.statusResult.type.toLowerCase() || "pending" : "none";
+          
+          // Reform the record for the table
           rec.id = `${rec.metadata.namespace}/${rec.metadata.name}`;
-          rec.scanjobs = scanJobMap[`${rec.metadata.namespace}/${rec.metadata.name}`] || [];
-          const status = rec.scanjobs?.[0]?.status?.statusResult?.type?.toLowerCase() || 'pending';
-          const prevStatus = rec.scanjobs?.[1]?.status?.statusResult?.type?.toLowerCase() || 'pending';
+          rec.currStatus = status;
+          rec.prevStatus = prevStatus;
+          rec.progress = scanjobs[0] && scanjobs[0].status.imageCount && scanjobs[0].status.scannedImageCount?
+            Math.ceil(scanjobs[0].status.scannedImageCount / scanjobs[0].status.imageCount * 100) : 0;
+          rec.prevProgress = scanjobs[1] && scanjobs[1].status.imageCount && scanjobs[1].status.scannedImageCount?
+            Math.ceil(scanjobs[1].status.scannedImageCount / scanjobs[1].status.imageCount * 100) : 0;
+          rec.error = scanjobs[0] && scanjobs[0].status.statusResult.type === "Failed" ? scanjobs[0].status.statusResult.message : "";
+
+          // Summarize the data for Latest status updates panel
           this.registryStatusList.push({
-            registry_name: rec.metadata.name,
+            registryName: rec.metadata.name,
             uri: rec.spec.uri,
             namespace: rec.metadata.namespace,
-            prev_status: prevStatus,
-            curr_status: status,
-            last_update_time: rec.scanjobs?.[0]?.status?.statusResult?.lastUpdateTime || rec.metadata.creationTimestamp,
+            prevStatus: prevStatus,
+            currStatus: status,
+            lastUpdateTime: scanjobs[0]?.status?.statusResult?.lastUpdateTime || rec.metadata.creationTimestamp,
           });
+
+          //Summarize the data for Status distribution panel
           if (status && this.statusSummary.hasOwnProperty(status)) {
             this.statusSummary[status]++;
           }
+
+          rec.availableActions.push({
+            action: 'startScan',
+            label: this.t('imageScanner.registries.buttons.startScan') || 'Start Scan',
+            icon: 'icon-play',
+            enabled: true,
+            invoke:   ({}, resources) => { this.startScan(resources); }
+          });
+
+          console.log("rec.availableActions", rec.availableActions)
           return rec;
         });
 
-        this.registryStatusList.sort((a, b) => new Date(b.last_update_time) - new Date(a.last_update_time)).slice(0, 5)
+        // Sort and limit the registryStatusList to 5 most recent updates
+        this.registryStatusList = this.registryStatusList.sort((a, b) => new Date(b.lastUpdateTime) - new Date(a.lastUpdateTime)).slice(0, 5);
         while (this.registryStatusList.length < 5) {
           this.registryStatusList.push({
-            registry_name: "",
+            registryName: "",
             uri: "",
-            prev_status: "",
-            curr_status: "",
-            last_update_time: new Date().toISOString()
+            prevStatus: "",
+            currStatus: "",
+            lastUpdateTime: new Date().toISOString()
           });
         }
       },
       refresh() {
         window.location.reload();
       },
-      async startScan() {
-        const table = this.$refs.table;
-        if ( !table ) {
-          return;
-        }
+      async startScan(selected) {
         const scanjobObj = await this.$store.dispatch('cluster/create', {
           type: RESOURCE.SCAN_JOB,
           metadata: {
-            generateName: this.selectedRows[0].metadata.name,
-            namespace: this.selectedRows[0].metadata.namespace,
+            generateName: selected?.[0]?.metadata.name || this.selectedRows[0].metadata.name,
+            namespace: selected?.[0]?.metadata.namespace || this.selectedRows[0].metadata.namespace,
           },
           spec: {
             registry: this.selectedRows[0].metadata.name,
@@ -161,10 +201,10 @@
         });
         try {
           await scanjobObj.save();
-          this.loadData();
+          // this.refresh();
           this.$store.dispatch('growl/success', {
             title: this.t('imageScanner.registries.messages.registryScanComplete'),
-            message: this.t('imageScanner.registries.messages.registryScanComplete', { name: selection[0].metadata.name }),
+            message: this.t('imageScanner.registries.messages.registryScanComplete', { name: this.selectedRows[0].metadata.name }),
           });
         } catch (e) {
           this.$store.dispatch('growl/error', {
@@ -176,6 +216,15 @@
       openAddEditRegistry() {},
       onSelectionChange(selected) {
         this.selectedRows = selected || [];
+      },
+      async promptRemoveRegistry() {
+        const table = this.$refs.table.$refs.table;
+        const act = findBy(table.availableActions, 'action', 'promptRemove');
+        if ( act ) {
+          table.setBulkActionOfInterest(act);
+          table.applyTableAction(act);
+        }
+        return;
       },
     },
     computed: {


### PR DESCRIPTION
For github issue [#61](https://github.com/neuvector/security-ui-exts/issues/61) and [#72](https://github.com/neuvector/security-ui-exts/issues/72)

Scan can be triggered and the status changes into "Scheduled" by backend.
Now the test is pending on the whole life cycle of scan. There is a issue [#86 ](https://github.com/neuvector/security-ui-exts/issues/86) can be tracked