### PR TITLE
Use regular page instead of resource page for registries configuration, Modified back routing on edit and detail page.

### DIFF
--- a/pkg/sbombastic-image-vulnerability-scanner/components/RegistryDetails.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/components/RegistryDetails.vue
@@ -5,7 +5,7 @@
         <div class="resource-header">
           <div class="resource-header-name-state">
             <span class="resource-header-name">
-              <RouterLink :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${ this.RESOURCE.REGISTRY }/`">{{ t('imageScanner.registries.title') }}:</RouterLink>
+              <RouterLink :to="`/c/${this.$route.params.cluster}/${ this.PRODUCT_NAME }/${this.PAGE.REGISTRIES}`">{{ t('imageScanner.registries.title') }}:</RouterLink>
               {{ $route.params.id }}
             </span>
             <RegisterStatusBadge :status="registryStatus" />
@@ -33,7 +33,7 @@
 
 <script>
   import { BadgeState } from '@rancher/components';
-  import { PRODUCT_NAME, RESOURCE } from '@sbombastic-image-vulnerability-scanner/types';
+  import { PRODUCT_NAME, RESOURCE, PAGE } from '@sbombastic-image-vulnerability-scanner/types';
   import ResourceTable from "@shell/components/ResourceTable";
   import RancherMeta from './common/RancherMeta.vue';
   import RegisterStatusBadge from './common/RegisterStatusBadge.vue';
@@ -53,6 +53,7 @@
       return {
         PRODUCT_NAME,
         RESOURCE,
+        PAGE,
         registry: null,
         registryStatus: null,
         registryMetadata: [],

--- a/pkg/sbombastic-image-vulnerability-scanner/config/sbombastic-image-vulnerability-scanner.ts
+++ b/pkg/sbombastic-image-vulnerability-scanner/config/sbombastic-image-vulnerability-scanner.ts
@@ -12,6 +12,19 @@ export function init($plugin: IPlugin, store: any) {
       icon: "pod_security",
       inStore: "cluster",
   });
+  
+  virtualType({
+    labelKey: 'imageScanner.registries.title',
+    name: PAGE.REGISTRIES,
+    namespaced: false,
+    route:    {
+        name:   `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}`,
+        params: {
+            product: PRODUCT_NAME
+        },
+        meta: { pkg: PRODUCT_NAME, product: PRODUCT_NAME }
+    }
+  });
 
   virtualType({
     labelKey: 'imageScanner.images.title',
@@ -72,6 +85,6 @@ export function init($plugin: IPlugin, store: any) {
         //"demo"
     ]);
 
-  basicType([RESOURCE.REGISTRY, PAGE.VEX_MANAGEMENT], 'Advanced');
+  basicType([PAGE.REGISTRIES, PAGE.VEX_MANAGEMENT], 'Advanced');
 
 }

--- a/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.registry.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.registry.vue
@@ -14,6 +14,7 @@ import {
   REGISTRY_TYPE_OPTIONS,
   SCAN_INTERVAL_OPTIONS, SCAN_INTERVALS
 } from "@sbombastic-image-vulnerability-scanner/constants/scan-interval-options";
+import { PRODUCT_NAME, PAGE } from "@sbombastic-image-vulnerability-scanner/types";
 
 export default {
   name: 'CruRegistry',
@@ -77,6 +78,44 @@ export default {
     },
   },
 
+  methods: {
+    apply(event) {
+      console.log('finish apply');
+      this.save(event)
+        .then(() => {
+          this.$emit('done');
+        })
+        .catch((e) => {
+          this.errors = e;
+        })
+        .finally(() => {
+          this.$router.push({
+            name: `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}`,
+            params: {
+              cluster: this.$route.params.cluster,
+              product: PRODUCT_NAME
+            }
+          });
+        });
+    },
+
+    cancel() {
+      console.log('cancel done');
+      this.done();
+      this.$router.push({
+        name: `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}`,
+        params: {
+          cluster: this.$route.params.cluster,
+          product: PRODUCT_NAME
+        }
+      });
+    },
+    doneRoute() {
+      console.log('doneRoute');
+      return `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}`;
+    },
+  },
+
   // Set default values for creating a new registry configuration
   created() {
     const spec = this.value.spec;
@@ -100,9 +139,10 @@ export default {
         :subtypes="[]"
         :validation-passed="true"
         :errors="errors"
+        :cancel-event="true"
         @error="(e) => (errors = e)"
-        @finish="save"
-        @cancel="done"
+        @finish="apply"
+        @cancel="cancel"
     >
       <NameNsDescription
           :value="value"

--- a/pkg/sbombastic-image-vulnerability-scanner/formatters/PreviousScanCell.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/formatters/PreviousScanCell.vue
@@ -13,13 +13,13 @@ export default {
   },
   methods: {
     getStatusText(row) {
-      return this.t(`imageScanner.enum.status.${row.prevScanStatus.toLowerCase()}`);
+      return this.t(`imageScanner.enum.status.${row.prevScanStatus?.toLowerCase()}`);
     },
     getStatusLabelClass(row) {
-      return row.prevScanStatus.toLowerCase();
+      return row.prevScanStatus?.toLowerCase();
     },
     getStatusDotClass(row) {
-      return `dot ${row.prevScanStatus.toLowerCase()}`;
+      return `dot ${row.prevScanStatus?.toLowerCase()}`;
     }
   }
 };
@@ -31,6 +31,9 @@ export default {
         <div class="status" :class="getStatusLabelClass(row)">{{ getStatusText(row) }}</div>
         <div v-if="row.prevProgress">
           <ProgressCell :status="{ progress: row.prevProgress, error: row.error }" />
+        </div>
+        <div v-if="row.prevScanStatus.toLowerCase() === 'failed' && row.error">
+          <span class="error-message">|<span style="margin-left: 10px;">{{ t("imageScanner.general.error") }}</span></span>
         </div>
     </div>
 </template>

--- a/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
+++ b/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
@@ -134,6 +134,7 @@ imageScanner:
     ago: ago
     justNow: Just now
     none: none
+    error: Error
 
 typeLabel:
   sbombastic.rancher.io.registry: Registries configuration

--- a/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/RegistriesConfiguration.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/RegistriesConfiguration.vue
@@ -1,16 +1,37 @@
 <template>
   <div>
-    <div>
-      <!-- <button
-        class="btn role-secondary"
-        style="position: absolute; top: 80px; right: 120px;"
-        @click="refresh()"
-      >
-        <i class="icon icon-refresh"></i>
-        {{ t('imageScanner.registries.button.refresh') || 'Refresh data' }}
-      </button> -->
+    <div class="header-section">
+      <div class="header-left">
+        <div class="title-wrap">
+          <div class="title">{{ t('imageScanner.registries.title') }}</div>
+        </div>
+        <div class="state">State as of <span class="state-date-time">{{ latestUpdateTimeText }}</span></div>
+      </div>
+      <div class="header-right">
+        <div class="header-btn">
+          <button
+            mat-button
+            class="btn role-secondary"
+            aria-label="Refresh data"
+            type="button"
+            :disabled="disabled"
+            @click="refresh()">
+            <em class="icon-refresh-ss"></em>{{ t('imageScanner.registries.button.refresh') }}
+          </button>
+        </div>
+        <div class="header-btn">
+          <button
+            mat-button
+            class="btn role-primary"
+            aria-label="Add new"
+            type="button"
+            :disabled="disabled"
+            @click="openAddEditRegistry()">
+            <em class="icon-add"></em>{{ t('imageScanner.registries.button.addNew') }}
+          </button>
+        </div>
+      </div>
     </div>
-    <div class="state">State as of <span class="state-date-time">{{ latestUpdateTimeText }}</span></div>
     <div class="summary-section">
       <RecentUpdatedRegistries :registryStatusList="registryStatusList"/>
       <StatusDistribution :chartData="statusSummary"/>
@@ -118,7 +139,16 @@ import { template } from "lodash";
       refresh() {
         this.loadData(true);
       },
-      openAddEditRegistry() {},
+      openAddEditRegistry() {
+        this.$router.push({
+          name: `${ PRODUCT_NAME }-c-cluster-resource-create`,
+          params: {
+            resource: RESOURCE.REGISTRY,
+            cluster: this.$route.params.cluster,
+            product: PRODUCT_NAME
+          }
+        });
+      },
       onSelectionChange(selected) {
         this.selectedRows = selected || [];
       },
@@ -141,6 +171,7 @@ import { template } from "lodash";
           rec.status.statusResult = statusIndex > -1 ? {
             type: rec.status.conditions[statusIndex].type,
             lastTransitionTime: rec.status.conditions[statusIndex].lastTransitionTime,
+            message: rec.status.conditions[statusIndex].message,
             statusIndex: statusIndex
           } : {
             type: "Pending",
@@ -209,7 +240,7 @@ import { template } from "lodash";
             enabled: true,
             invoke:   ({}, resources) => { this.startScan(resources); }
           });
-
+          console.log("rec", rec)
           console.log("rec.availableActions", rec.availableActions)
           return rec;
         }); 
@@ -338,14 +369,14 @@ import { template } from "lodash";
       width: 16px;
       height: 16px;
       margin-right: 12px;
-      background: url('../assets/img/add.svg') no-repeat center center;
+      background: url('../../../../assets/img/add.svg') no-repeat center center;
       background-size: contain;
     }
     .icon-refresh-ss {
       width: 16px;
       height: 16px;
       margin-right: 12px;
-      background: url('../assets/img/refresh.svg') no-repeat center center;
+      background: url('../../../../assets/img/refresh.svg') no-repeat center center;
       background-size: contain;
     }
   }

--- a/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/create.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/create.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+export default {
+  name:       'SbomBasticResourceCreate',
+  components: { ResourceDetail },
+};
+</script>
+
+<template>
+  <ResourceDetail />
+</template>

--- a/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/index.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/index.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceList from '@shell/components/ResourceList/index.vue';
+
+export default {
+  name:       'SbomBasticResourcedList',
+  components: { ResourceList },
+};
+</script>
+
+<template>
+  <ResourceList />
+</template>

--- a/pkg/sbombastic-image-vulnerability-scanner/routes/sbombastic-image-vulnerability-scanner-routes.ts
+++ b/pkg/sbombastic-image-vulnerability-scanner/routes/sbombastic-image-vulnerability-scanner-routes.ts
@@ -1,10 +1,11 @@
 import RegistryDetails from "@sbombastic-image-vulnerability-scanner/components/RegistryDetails.vue";
 import ComponentDemo from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/ComponentDemo.vue";
 import ImageOverview from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/ImageOverview.vue";
-import Registries from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/Registries.vue";
+import RegistriesConfiguration from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/RegistriesConfiguration.vue";
 import Vulnerabilities from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/Vulnerabilities.vue";
 import VexManagement from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/VexManagement.vue";
-
+import CreateResource from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/create.vue";
+import ListResource from "@sbombastic-image-vulnerability-scanner/pages/c/_cluster/sbombastic-image-vulnerability-scanner/_resource/index.vue";
 import {
   PRODUCT_NAME,
   PAGE,
@@ -32,9 +33,30 @@ const routes = [
     component: ComponentDemo,
   },
   {
+    name: `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}`,
+    path: `/c/:cluster/${PRODUCT_NAME}/${PAGE.REGISTRIES}`,
+    component: RegistriesConfiguration,
+  },
+  {
     name: `c-cluster-${PRODUCT_NAME}-${PAGE.REGISTRIES}-id`,
     path: `/c/:cluster/${PRODUCT_NAME}/${PAGE.REGISTRIES}/:ns/:id`,
     component: RegistryDetails,
+  },
+  {
+    name:      `${ PRODUCT_NAME }-c-cluster-resource-create`,
+    path:      `/${ PRODUCT_NAME }/c/:cluster/:resource/create`,
+    component: CreateResource,
+    meta:      {
+      product: PRODUCT_NAME,
+    },
+  },
+  {
+    name:      `${ PRODUCT_NAME }-c-cluster-resource`,
+    path:      `/${ PRODUCT_NAME }/c/:cluster/:resource`,
+    component: ListResource,
+    meta:      {
+      product: PRODUCT_NAME,
+    },
   },
 ];
 


### PR DESCRIPTION
Refactor the page routing.
Use regular registries configuration page instead of sbombastic registry resource page, as resource page is only for single resource. The registries configuration page's data source is from multiple CRDs.

Modified routing for navigating back in edit registry page and registry scan detail page