### PR TITLE
Bug Fixes

### DIFF
--- a/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.registry.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.registry.vue
@@ -135,6 +135,7 @@ export default {
         @cancel="done"
     >
       <NameNsDescription
+          nameLabel="imageScanner.registries.configuration.cru.registry.label"
           :value="value"
           :mode="mode"
           @update:value="$emit('input', $event)"
@@ -161,6 +162,7 @@ export default {
               :label="t('imageScanner.registries.configuration.cru.registry.uri.label')"
               v-model:value="value.spec.uri"
               :placeholder="t('imageScanner.registries.configuration.cru.registry.uri.placeholder')"
+              required
           />
         </div>
       </div>

--- a/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.vexhub.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/edit/sbombastic.rancher.io.vexhub.vue
@@ -55,6 +55,7 @@ export default {
           :value="value"
           :mode="mode"
           :namespaced=false
+          descriptionPlaceholder="imageScanner.vexManagement.cru.desc.placeholder"
           @update:value="$emit('input', $event)"
       />
       <div class="row">
@@ -63,6 +64,7 @@ export default {
               v-model:value="value.spec.url"
               :mode="mode"
               :label="t('imageScanner.vexManagement.cru.uri.label')"
+              placeholderKey="imageScanner.vexManagement.cru.uri.placeholder"
               :required="true"
           />
         </div>

--- a/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
+++ b/pkg/sbombastic-image-vulnerability-scanner/l10n/en-us.yaml
@@ -128,8 +128,11 @@ imageScanner:
     cru:
       description: Start from scratch by using the steps below or go back and clone an existing entry
       name: Name
+      desc:
+        placeholder: Any text you want that better describes this entry
       uri:
         label: VEX hub URI
+        placeholder: A valid URI address
       enable:
         label: Enabled
         tooltip: Controls whether this VEX entry is active in vulnerability assessments.


### PR DESCRIPTION
1. Registry Configuration - Edit Page
- Marked URI and Scan Interval fields as required inputs

2. VEX Management - Edit page
- Updated the Description field
- Added missing Navigation link
- Added a placeholder for the VEX hub URI field

<img width="1067" height="608" alt="Screenshot 2025-08-26 at 11 26 00 AM" src="https://github.com/user-attachments/assets/928cdd91-d486-4133-9795-4161cd224f7e" />


<img width="1126" height="341" alt="Screenshot 2025-08-26 at 11 26 13 AM" src="https://github.com/user-attachments/assets/2250c29b-c14c-464b-86b7-9a255997e978" />