### PR TITLE
Fix multi-column overview bug

### DIFF
--- a/pkg/sbombastic-image-vulnerability-scanner/components/ImageDetails.vue
+++ b/pkg/sbombastic-image-vulnerability-scanner/components/ImageDetails.vue
@@ -1231,7 +1231,7 @@ export default {
           `"${ vuln.exploitability || '' }"`,
           `"${ vuln.installedVersion || '' }"`,
           `"${ vuln.packagePath || '' }"`,
-          `"${ vuln.description.replace(/[\r\n]+/g, ' ') }"`,
+          `"${ vuln.description.replace(/\"/g, "'").replace(/[\r\n]+/g, ' ') }"`,
         ];
 
         csvRows.push(row.join(','));
@@ -1268,7 +1268,7 @@ export default {
           `"${ vuln.exploitability || '' }"`,
           `"${ vuln.installedVersion || '' }"`,
           `"${ vuln.packagePath || '' }"`,
-          `"${ vuln.description.replace(/[\r\n]+/g, ' ') }"`,
+          `"${ vuln.description.replace(/\"/g, "'").replace(/[\r\n]+/g, ' ') }"`,
         ];
 
         csvRows.push(row.join(','));

--- a/pkg/sbombastic-image-vulnerability-scanner/utils/csv.ts
+++ b/pkg/sbombastic-image-vulnerability-scanner/utils/csv.ts
@@ -11,7 +11,7 @@ export function imageDetailsToCSV(vuls: ImageVulnerability[]): Object[] {
       EXPLOITABILITY: vul.suppressed ? 'Suppressed' : 'Affected',
       "PACKAGE VERSION": vul.installedVersion,
       "PACKAGE PATH": vul.purl,
-      DESCRIPTION: vul.description.replace(/[\r\n]+/g, " "),
+      DESCRIPTION: vul.description.replace(/\"/g, "'").replace(/[\r\n]+/g, ' '),
     };
   });
 }


### PR DESCRIPTION
Replace double quotes with single in description field to prevent parsing across column boundary.
Fixes #223 