### PR TITLE
Fix image detail page Exploitability column l10n bug

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/ImageDetails.vue
+++ b/pkg/sbomscanner-ui-ext/components/ImageDetails.vue
@@ -392,7 +392,7 @@ export default {
         fixAvailable:     vuln.fixedVersions && vuln.fixedVersions.length > 0,
         fixVersion:       vuln.fixedVersions ? vuln.fixedVersions.join(', ') : '',
         severity:         vuln.severity?.toLowerCase() || this.t('imageScanner.general.unknown'),
-        exploitability:   vuln.suppressed ? this.t('imageDetails.suppressed') : this.t('imageDetails.affected'),
+        exploitability:   vuln.suppressed ? this.t('imageScanner.imageDetails.suppressed') : this.t('imageScanner.imageDetails.affected'),
         description:      vuln.description,
         title:            vuln.title,
         references:       vuln.references || [],


### PR DESCRIPTION
Fixes #289 

Before:
<img width="1249" height="356" alt="Screenshot 2025-10-29 at 4 09 25 PM" src="https://github.com/user-attachments/assets/2dbb0c8c-9e7d-498f-a8ed-fba40d193824" />


After:
<img width="1186" height="484" alt="Screenshot 2025-10-29 at 4 11 28 PM" src="https://github.com/user-attachments/assets/027d9e83-13e8-4314-9cc0-03f135ef5e84" />
