### PR TITLE
Fix build script errors in sbomscanner-ui-ext

### DIFF
--- a/pkg/sbomscanner-ui-ext/vue.config.js
+++ b/pkg/sbomscanner-ui-ext/vue.config.js
@@ -1,1 +1,26 @@
-module.exports = require('./.shell/pkg/vue.config')(__dirname);
+// Load Rancher’s base Vue config
+const baseConfig = require('./.shell/pkg/vue.config')(__dirname);
+
+module.exports = {
+  ...baseConfig,
+  configureWebpack: (config) => {
+    // Run base Rancher config first
+    if (typeof baseConfig.configureWebpack === 'function') {
+      baseConfig.configureWebpack(config);
+    } else if (typeof baseConfig.configureWebpack === 'object') {
+      Object.assign(config, baseConfig.configureWebpack);
+    }
+
+    // Explicitly disable or polyfill Node core modules
+    config.resolve = config.resolve || {};
+    config.resolve.fallback = {
+      ...(config.resolve.fallback || {}),
+      fs:     false,
+      module: false,
+      path:   false,
+      os:     false,
+      crypto: false,
+      stream: false,
+    };
+  },
+};


### PR DESCRIPTION
Fixes `build-pkg` errors caused by lack of polyfills for Node.js modules