### PR TITLE
Fix build script errors in sbomscanner-ui-ext

### DIFF
--- a/pkg/sbomscanner-ui-ext/vue.config.js
+++ b/pkg/sbomscanner-ui-ext/vue.config.js
@@ -1,26 +1,15 @@
-// Load Rancher’s base Vue config
+const webpack = require('webpack');
 const baseConfig = require('./.shell/pkg/vue.config')(__dirname);
 
 module.exports = {
   ...baseConfig,
-  configureWebpack: (config) => {
-    // Run base Rancher config first
-    if (typeof baseConfig.configureWebpack === 'function') {
-      baseConfig.configureWebpack(config);
-    } else if (typeof baseConfig.configureWebpack === 'object') {
-      Object.assign(config, baseConfig.configureWebpack);
+  chainWebpack: (config) => {
+    if (typeof baseConfig.chainWebpack === 'function') {
+      baseConfig.chainWebpack(config);
     }
 
-    // Explicitly disable or polyfill Node core modules
-    config.resolve = config.resolve || {};
-    config.resolve.fallback = {
-      ...(config.resolve.fallback || {}),
-      fs:     false,
-      module: false,
-      path:   false,
-      os:     false,
-      crypto: false,
-      stream: false,
-    };
+    config.plugin('ignore-tests')
+      .use(webpack.IgnorePlugin, [{ resourceRegExp: /[\\/]__tests__[\\/]/ }]);
   },
+  configureWebpack: baseConfig.configureWebpack,
 };


### PR DESCRIPTION
Reverts changes in #324. Instead uses rancher/kubewarden-ui strategy: Exclude testing files from where Node.js modules are imported