### PR TITLE
Bug: UI should prevent user from creating multiple empty platform selections in Create/Edit registry page

### DIFF
--- a/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.registry.spec.ts
+++ b/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.registry.spec.ts
@@ -397,12 +397,38 @@ describe('CruRegistry', () => {
 
     it('should NOT delete scanInterval if not MANUAL', async() => {
       save.mockResolvedValue({});
-      wrapper.vm.value.spec.scanInterval = SCAN_INTERVALS.DAILY;
+      wrapper.vm.value.spec.scanInterval = SCAN_INTERVALS.ONE_HOUR;
       await wrapper.vm.$nextTick();
       await wrapper.vm.finish();
-      expect(wrapper.vm.value.spec.scanInterval).toBe(SCAN_INTERVALS.DAILY);
+      expect(wrapper.vm.value.spec.scanInterval).toBe(SCAN_INTERVALS.ONE_HOUR);
       expect(save).toHaveBeenCalled();
       expect(mockRouter.push).toHaveBeenCalled();
+    });
+
+    it('should remove duplicates and empty platforms before saving', async() => {
+      save.mockResolvedValue({});
+      wrapper.vm.value.spec.platforms = [
+        {
+          os: 'linux', arch: 'amd64', variant: ''
+        },
+        {
+          os: 'linux', arch: 'amd64', variant: ''
+        },
+        {
+          os: '', arch: '', variant: ''
+        },
+        {
+          os: 'windows', arch: 'amd64', variant: ''
+        }
+      ];
+
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.finish();
+
+      expect(wrapper.vm.value.spec.platforms).toHaveLength(2);
+      expect(wrapper.vm.value.spec.platforms[0].os).toBe('linux');
+      expect(wrapper.vm.value.spec.platforms[1].os).toBe('windows');
+      expect(save).toHaveBeenCalled();
     });
 
     it('should set errors and not route on save failure', async() => {

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
@@ -215,6 +215,8 @@ export default {
         delete this.value.spec.scanInterval;
       }
 
+      this.cleanPlatforms();
+
       try {
         await this.save(event);
       } catch (e) {
@@ -302,6 +304,25 @@ export default {
     isVariantSupported(arch) {
       return !!ALLOWED_VARIANTS[arch];
     },
+
+    cleanPlatforms() {
+      if (!this.value.spec.platforms) return;
+      const uniqueSet = new Set();
+
+      this.value.spec.platforms = this.value.spec.platforms.filter((p) => {
+        if (!p.os || !p.arch) {
+          return false;
+        }
+        const key = `${p.os}-${p.arch}-${p.variant || ''}`;
+
+        if (uniqueSet.has(key)) {
+          return false;
+        }
+        uniqueSet.add(key);
+
+        return true;
+      });
+    }
   }
 };
 </script>


### PR DESCRIPTION
Trim duplicate platform items when saving registry configuration

<img width="1641" height="571" alt="Screenshot 2026-01-12 at 10 21 05 AM" src="https://github.com/user-attachments/assets/8210abc5-5c9b-46a8-bcb3-3ba39cf297ea" />
<img width="1630" height="881" alt="Screenshot 2026-01-12 at 10 21 37 AM" src="https://github.com/user-attachments/assets/7157cb29-b7c7-43c5-a8ae-347844fa3c2e" />
