### PR TITLE
Feat: Add vulnerabilities bar chart popup for the stacked bar chart #391

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue
@@ -1,0 +1,261 @@
+<template>
+  <div
+      ref="trigger"
+      class="vulnerability-hover-cell"
+      @mouseenter="checkPosition"
+  >
+    <div class="trigger-bar">
+      <AmountBarBySeverity
+          :cve-amount="cveAmount"
+          :is-collapsed="true"
+      />
+    </div>
+
+    <div
+        class="hover-overlay"
+        :class="{ 'show-top': showOnTop }"
+    >
+      <div class="header">
+        <div class="title">
+          {{ headerTitle || `${totalVulnerabilities} vulnerabilities` }}
+        </div>
+        <a
+            v-if="viewAllLink"
+            :href="viewAllLink"
+            class="view-all"
+            @click.stop="$emit('view-all')"
+        >
+          View all
+        </a>
+      </div>
+
+      <div class="severity-list">
+        <div v-for="severity in severities" :key="severity.key" class="severity-row">
+          <span class="label">{{ severity.label }}</span>
+
+          <div class="bar-container">
+            <div
+                class="progress-bar"
+                :class="severity.key"
+                :style="{ width: getPercentage(severity.key) + '%' }"
+            ></div>
+          </div>
+
+          <span class="count">{{ cveAmount[severity.key] || 0 }}</span>
+        </div>
+      </div>
+
+      <div class="footer">
+        Provided by <span class="provider-name">{{ footerProvider }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import AmountBarBySeverity from './AmountBarBySeverity.vue';
+
+export default {
+  name: 'VulnerabilityHoverCell',
+  components: { AmountBarBySeverity },
+  props: {
+    cveAmount: {
+      type: Object,
+      required: true,
+      default: () => ({ critical: 0, high: 0, medium: 0, low: 0, unknown: 0 })
+    },
+    headerTitle: {
+      type: String,
+      default: ''
+    },
+    viewAllLink: {
+      type: String,
+      default: ''
+    },
+    footerProvider: {
+      type: String,
+      default: 'SBOMScanner'
+    }
+  },
+  data() {
+    return {
+      showOnTop: false,
+      severities: [
+        { key: 'critical', label: 'Critical' },
+        { key: 'high', label: 'High' },
+        { key: 'medium', label: 'Medium' },
+        { key: 'low', label: 'Low' },
+        { key: 'unknown', label: 'None' }
+      ]
+    };
+  },
+  computed: {
+    totalVulnerabilities() {
+      return Object.values(this.cveAmount).reduce((a, b) => a + (Number(b) || 0), 0);
+    }
+  },
+  methods: {
+    checkPosition() {
+      if (!this.$refs.trigger) return;
+      const trigger = this.$refs.trigger.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      this.showOnTop = (viewportHeight - trigger.bottom < 300);
+    },
+    getPercentage(key) {
+      const count = this.cveAmount[key] || 0;
+      if (this.totalVulnerabilities === 0) return 0;
+      return (count / this.totalVulnerabilities) * 100;
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import '../../styles/_variables.scss';
+
+$gap-size: 10px;
+
+.vulnerability-hover-cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+
+  // Show popup on hover
+  &:hover .hover-overlay {
+    display: block;
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &:hover .trigger-bar {
+    border-color: var(--border);
+  }
+}
+
+.trigger-bar {
+  width: 100%;
+  padding: 4px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  transition: border-color 0.2s;
+}
+
+.hover-overlay {
+  display: none;
+  position: absolute;
+  top: calc(100% + #{$gap-size});
+  right: 0; // Align to right of cell
+
+  width: 320px;
+  background: var(--popover-bg);
+  border: var(--popover-border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 16px;
+  z-index: 100;
+  font-family: Lato, sans-serif;
+  color: #141419;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: $gap-size;
+    top: -$gap-size;
+    background: transparent;
+  }
+
+  &.show-top {
+    top: auto;
+    bottom: calc(100% + #{$gap-size});
+
+    &::before {
+      top: auto;
+      bottom: -$gap-size;
+    }
+  }
+}
+
+// --- Header ---
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+
+  .title {
+    font-weight: 700;
+    font-size: 16px;
+  }
+
+  .view-all {
+    font-size: 14px;
+    color: #004ecc;
+    text-decoration: none;
+    cursor: pointer;
+    &:hover { text-decoration: underline; }
+  }
+}
+
+// --- List Rows ---
+.severity-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 13px;
+
+  .label {
+    width: 60px;
+    text-decoration: underline;
+    text-decoration-color: #eee;
+    text-underline-offset: 3px;
+  }
+
+  .bar-container {
+    flex-grow: 1;
+    height: 8px;
+    background-color: #ebedf6;
+    border-radius: 4px;
+    margin: 0 12px;
+    overflow: hidden;
+  }
+
+  .progress-bar {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+  }
+
+  .count {
+    width: 30px;
+    text-align: right;
+    font-weight: 600;
+    color: #5d5d5d;
+  }
+}
+
+// --- Footer ---
+.footer {
+  margin-top: 12px;
+  text-align: right;
+  font-size: 12px;
+  color: #8d9096;
+
+  .provider-name {
+    text-decoration: underline;
+    color: #5d5d5d;
+  }
+}
+
+// --- Colors (Map to variables) ---
+.critical { background-color: $critical-color; }
+.high     { background-color: $high-color; }
+.medium   { background-color: $medium-color; }
+.low      { background-color: $low-color; }
+.unknown  { background-color: $na-color; }
+
+</style>

--- a/pkg/sbomscanner-ui-ext/components/common/__tests__/VulnerabilityHoverCell.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/common/__tests__/VulnerabilityHoverCell.spec.ts
@@ -1,0 +1,149 @@
+import { shallowMount, mount } from '@vue/test-utils';
+import VulnerabilityHoverCell from '../VulnerabilityHoverCell.vue';
+
+const AmountBarBySeverityStub = {
+  template: '<div class="amount-bar-stub"></div>',
+  props: ['cveAmount', 'isCollapsed']
+};
+
+describe('VulnerabilityHoverCell.vue', () => {
+  const defaultCve = {
+    critical: 10,
+    high: 20,
+    medium: 10,
+    low: 10,
+    unknown: 0
+  };
+
+  const createWrapper = (props = {}) => {
+    return shallowMount(VulnerabilityHoverCell, {
+      props: {
+        cveAmount: defaultCve,
+        ...props
+      },
+      global: {
+        stubs: {
+          AmountBarBySeverity: AmountBarBySeverityStub
+        }
+      }
+    });
+  };
+
+  it('renders correctly', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('.trigger-bar').exists()).toBe(true);
+  });
+
+  describe('Computed Properties', () => {
+    it('calculates totalVulnerabilities correctly', () => {
+      const wrapper = createWrapper({
+        cveAmount: { critical: 1, high: 2, medium: 3, low: 4, unknown: 0 } // Sum = 10
+      });
+      expect((wrapper.vm as any).totalVulnerabilities).toBe(10);
+    });
+
+    it('handles string inputs in cveAmount gracefully', () => {
+      const wrapper = createWrapper({
+        cveAmount: { critical: "5", high: "5", medium: 0, low: 0, unknown: 0 } // Sum = 10
+      });
+      expect((wrapper.vm as any).totalVulnerabilities).toBe(10);
+    });
+
+    it('getPercentage() calculates correct width %', () => {
+      const wrapper = createWrapper({ cveAmount: defaultCve }); // Total 50
+      const vm = wrapper.vm as any;
+
+      expect(vm.getPercentage('critical')).toBe(20);
+      expect(vm.getPercentage('high')).toBe(40);
+      expect(vm.getPercentage('unknown')).toBe(0);
+    });
+
+    it('getPercentage() returns 0 if total is 0 (avoids NaN)', () => {
+      const wrapper = createWrapper({
+        cveAmount: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
+      });
+      expect((wrapper.vm as any).getPercentage('critical')).toBe(0);
+    });
+  });
+
+  describe('Rendering Content', () => {
+    it('displays default header title with count when no title prop provided', () => {
+      const wrapper = createWrapper();
+      const title = wrapper.find('.title');
+      expect(title.text()).toContain('50 vulnerabilities');
+    });
+
+    it('displays custom headerTitle when provided', () => {
+      const wrapper = createWrapper({ headerTitle: 'Custom Report' });
+      expect(wrapper.find('.title').text()).toBe('Custom Report');
+    });
+
+    it('renders "View all" link only when viewAllLink prop exists', () => {
+      const wrapper = createWrapper({ viewAllLink: '/details' });
+      const link = wrapper.find('a.view-all');
+
+      expect(link.exists()).toBe(true);
+      expect(link.attributes('href')).toBe('/details');
+    });
+
+    it('does NOT render "View all" link if prop is missing', () => {
+      const wrapper = createWrapper({ viewAllLink: '' });
+      expect(wrapper.find('.view-all').exists()).toBe(false);
+    });
+
+    it('renders the footer provider name', () => {
+      const wrapper = createWrapper({ footerProvider: 'My Scanner' });
+      expect(wrapper.find('.provider-name').text()).toBe('My Scanner');
+    });
+
+    it('renders exactly 5 severity rows with correct labels', () => {
+      const wrapper = createWrapper();
+      const rows = wrapper.findAll('.severity-row');
+
+      expect(rows.length).toBe(5);
+      expect(rows[0].find('.label').text()).toBe('Critical');
+      expect(rows[4].find('.label').text()).toBe('None'); // Maps to 'unknown'
+    });
+
+    it('applies correct width style to progress bars', () => {
+      const wrapper = createWrapper();
+      const criticalBar = wrapper.find('.progress-bar.critical');
+      expect(criticalBar.attributes('style')).toContain('width: 20%;');
+    });
+  });
+
+  describe('Interactions & Logic', () => {
+    it('emits "view-all" event when View All link is clicked', async () => {
+      const wrapper = createWrapper({ viewAllLink: '#' });
+      await wrapper.find('.view-all').trigger('click');
+
+      expect(wrapper.emitted('view-all')).toBeTruthy();
+      expect(wrapper.emitted('view-all')).toHaveLength(1);
+    });
+
+    it('toggles "showOnTop" (CSS class) based on viewport calculation', async () => {
+      const wrapper = createWrapper();
+      const vm = wrapper.vm as any;
+      window.innerHeight = 1000;
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({
+        bottom: 100, // 900px remaining space ( > 300 threshold)
+        top: 0, left: 0, right: 0, width: 0, height: 0
+      } as DOMRect));
+
+      await wrapper.find('.vulnerability-hover-cell').trigger('mouseenter');
+      expect(vm.showOnTop).toBe(false);
+      expect(wrapper.find('.hover-overlay').classes()).not.toContain('show-top');
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({
+        bottom: 900, // 100px remaining space ( < 300 threshold)
+        top: 0, left: 0, right: 0, width: 0, height: 0
+      } as DOMRect));
+
+      await wrapper.find('.vulnerability-hover-cell').trigger('mouseenter');
+      expect(vm.showOnTop).toBe(true);
+
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('.hover-overlay').classes()).toContain('show-top');
+    });
+  });
+});


### PR DESCRIPTION

<img width="1319" height="250" alt="Screenshot 2026-02-01 at 9 19 16 PM" src="https://github.com/user-attachments/assets/f36e70ec-3c9c-456b-afa0-c0f4c3e1455a" />


Example Usage: VulnerabilityHoverCell.vue
Template Implementation:

``` HTML
<SortableTable
    :rows="mockRows"
    :headers="tableHeaders"
    :search="false"
    :table-actions="false"
    :row-actions="false"
    key-field="id"
>
    <template #col:vulnerabilities="{ row }">
        <td data-title="vulnerabilities">
            <VulnerabilityHoverCell
                :cve-amount="row.vulnerabilitySummary"
                :header-title="`${row.totalVulnerabilities} Total Issues`"
                :view-all-link="`/demo/${row.id}/all`"
                footer-provider="SBOMScanner"
            />
        </td>
    </template>
</SortableTable>
```

Mock Data Structure (mockRows):

``` JavaScript
const mockRows = [
    {
        id: '1',
        name: 'frontend-app',
        image: 'nginx:1.19',
        totalVulnerabilities: 78,
        vulnerabilitySummary: {
            critical: 32, high: 0, medium: 18, low: 9, unknown: 19
        }
    },
    {
        id: '2',
        name: 'backend-api',
        image: 'node:14-alpine',
        totalVulnerabilities: 12,
        vulnerabilitySummary: {
            critical: 2, high: 5, medium: 5, low: 0, unknown: 0
        }
    }
];
```

Table Headers Configuration:

``` JavaScript
export const tableHeaders = [
    {
        name: 'name',
        label: 'Workload Name',
        value: 'name',
        sort: 'name',
        width: '30%'
    },
    {
        // This 'name' must match the slot name #col:vulnerabilities
        name: 'vulnerabilities',
        label: 'Vulnerabilities',
        value: 'totalVulnerabilities', 
        sort: 'totalVulnerabilities',
        width: '25%'
    },
    {
        name: 'image',
        label: 'Image',
        value: 'image',
        sort: 'image',
        width: '45%'
    }
];
```