### PR TITLE
#392 [Feat] Tab level plugin for vulnerabilities list in Deployment page (Add image filter on vulnerability table with mockdata)

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/common/VulnerabilityTableSet.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/VulnerabilityTableSet.vue
@@ -91,6 +91,21 @@
           :multiple="false"
           />
       </div>
+      <div class="filter-item" v-if="isInWorkloadContext">
+          <label>{{ t('imageScanner.imageDetails.table.headers.images') }}</label>
+          <div class="filter-input-wrapper">
+            <input
+                v-model="filters.imageSearch"
+                type="text"
+                :placeholder="t('imageScanner.imageDetails.searchByName')"
+                class="filter-input"
+            />
+            <i
+                class="icon icon-search"
+                style="color: #6C6C76; margin-left: 8px;"
+            ></i>
+          </div>
+      </div>
     </div>
   </div>
 
@@ -140,6 +155,7 @@ export default {
         scoreMin:       '',
         scoreMax:       '',
         packageSearch:  '',
+        imageSearch:    '',
         fixAvailable:   'any',
         severity:       'any',
         exploitability: 'any',
@@ -205,7 +221,32 @@ export default {
     },
 
     updateFilteredVulnerabilities() {
+
       let filtered = [...this.vulnerabilityDetails];
+
+      // Mock images field for workload context - start
+      filtered = filtered.map((vul) => {
+        if (vul.cveId === 'CVE-2024-58251' || vul.cveId === 'CVE-2024-58252') {
+          return {
+            ...vul,
+            images: vul.images ? vul.images : [
+              'ghcr.io/linuxcontainers/alpine:3',
+              'registry-1.docker.io/library/alpine:3.13.6',
+              'registry.example.com/workload/app-backend:1.0.0',
+              'registry.example.com/workload/app-frontend:2.1.0',
+            ],
+          };
+        } else {
+          return {
+            ...vul,
+            images: vul.images ? vul.images : [
+              'ghcr.io/linuxcontainers/alpine:3',
+              'registry-1.docker.io/library/alpine:3.13.6',
+            ],
+          };
+        }
+      });
+      // Mock images field for workload context - end
 
       // CVE search filter
       if (this.filters.cveSearch && this.filters.cveSearch.trim()) {
@@ -229,6 +270,11 @@ export default {
       if (this.filters.packageSearch && this.filters.packageSearch.trim()) {
         filtered = filtered.filter((v) => v.package && v.package.toLowerCase().includes(this.filters.packageSearch.toLowerCase())
         );
+      }
+
+      // Image search filter
+      if (this.filters.imageSearch && this.filters.imageSearch.trim()) {
+        filtered = filtered.filter((v) => v.images && v.images.some((img) => img.toLowerCase().includes(this.filters.imageSearch.toLowerCase())));
       }
 
       // Fix available filter

--- a/pkg/sbomscanner-ui-ext/config/table-headers.ts
+++ b/pkg/sbomscanner-ui-ext/config/table-headers.ts
@@ -464,7 +464,7 @@ export const WORKLOAD_VULNERABILITY_DETAILS_TABLE = [
   {
     name:     'images',
     labelKey: 'imageScanner.imageDetails.table.headers.images',
-    value:    'images',
+    value:    (row: any) => row.images ? row.images.length : 0,
     sort:     'images',
   },
 ];


### PR DESCRIPTION
<img width="1728" height="963" alt="Screenshot 2026-02-04 at 11 36 00 AM" src="https://github.com/user-attachments/assets/5dade428-41d6-42ea-9e71-5685cc001e2e" />
