### PR TITLE
integrate vulnerability hover popup to image overview page and refactor data processing #391

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue
@@ -116,14 +116,19 @@ export default {
 $gap-size: 10px;
 
 .vulnerability-hover-cell {
+
+  --severity-critical: #{$critical-color};
+  --severity-high: #{$high-color};
+  --severity-medium: #{$medium-color};
+  --severity-low: #{$low-color};
+  --severity-unknown: #{$na-color};
+
   position: relative;
   display: flex;
   align-items: center;
   width: 100%;
   height: 100%;
-  cursor: pointer;
 
-  // Show popup on hover
   &:hover .hover-overlay {
     display: block;
     visibility: visible;
@@ -147,8 +152,7 @@ $gap-size: 10px;
   display: none;
   position: absolute;
   top: calc(100% + #{$gap-size});
-  right: 0; // Align to right of cell
-
+  right: 10px;
   width: 320px;
   background: var(--popover-bg);
   border: var(--popover-border);
@@ -157,7 +161,7 @@ $gap-size: 10px;
   padding: 16px;
   z-index: 100;
   font-family: Lato, sans-serif;
-  color: #141419;
+  color: var(--text-primary);
 
   &::before {
     content: '';
@@ -180,7 +184,6 @@ $gap-size: 10px;
   }
 }
 
-// --- Header ---
 .header {
   display: flex;
   justify-content: space-between;
@@ -190,18 +193,17 @@ $gap-size: 10px;
   .title {
     font-weight: 700;
     font-size: 16px;
+    color: var(--text-primary);
   }
 
   .view-all {
     font-size: 14px;
-    color: #004ecc;
     text-decoration: none;
     cursor: pointer;
     &:hover { text-decoration: underline; }
   }
 }
 
-// --- List Rows ---
 .severity-row {
   display: flex;
   align-items: center;
@@ -211,14 +213,14 @@ $gap-size: 10px;
   .label {
     width: 60px;
     text-decoration: underline;
-    text-decoration-color: #eee;
+    text-decoration-color: var(--border);
     text-underline-offset: 3px;
   }
 
   .bar-container {
     flex-grow: 1;
     height: 8px;
-    background-color: #ebedf6;
+    background-color: var(--disabled-bg);
     border-radius: 4px;
     margin: 0 12px;
     overflow: hidden;
@@ -234,24 +236,22 @@ $gap-size: 10px;
     width: 30px;
     text-align: right;
     font-weight: 600;
-    color: #5d5d5d;
+    color: var(--text-secondary);
   }
 }
 
-// --- Footer ---
 .footer {
   margin-top: 12px;
   text-align: right;
   font-size: 12px;
-  color: #8d9096;
+  color: var(--text-secondary);
 
   .provider-name {
     text-decoration: underline;
-    color: #5d5d5d;
+    color: var(--text-secondary);
   }
 }
 
-// --- Colors (Map to variables) ---
 .critical { background-color: $critical-color; }
 .high     { background-color: $high-color; }
 .medium   { background-color: $medium-color; }

--- a/pkg/sbomscanner-ui-ext/config/table-headers.ts
+++ b/pkg/sbomscanner-ui-ext/config/table-headers.ts
@@ -257,7 +257,7 @@ export const REPO_BASED_TABLE = [
   {
     name:      'cves',
     labelKey:  'imageScanner.images.listTable.headers.vulnerabilities',
-    value:     'cveCntByRepo',
+    value:     'cveSummary',
     formatter: 'IdentifiedCVEsPercentageCell',
     sort:      'cveCntByRepo',
     width:     300,

--- a/pkg/sbomscanner-ui-ext/formatters/IdentifiedCVEsPercentageCell.vue
+++ b/pkg/sbomscanner-ui-ext/formatters/IdentifiedCVEsPercentageCell.vue
@@ -1,20 +1,26 @@
 <template>
   <div style="margin-right: 32px;">
-    <AmountBarBySeverity
-      :cve-amount="value"
-      :is-collapsed="true"
+    <VulnerabilityHoverCell
+        :cve-amount="value.cveAmount"
+        :header-title="`${value.total} ${t('imageScanner.images.listTable.headers.vulnerabilities')}`"
+        :view-all-link="value.link"
     />
   </div>
 </template>
 <script>
-import AmountBarBySeverity from '@sbomscanner-ui-ext/components/common/AmountBarBySeverity';
+import VulnerabilityHoverCell from "@sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue";
 export default {
   props: {
     value: {
       type:     Object,
-      required: true
+      required: true,
+      default: () => ({
+        cveAmount: {},
+        total: 0,
+        link: ''
+      })
     }
   },
-  components: { AmountBarBySeverity },
+  components: {VulnerabilityHoverCell },
 };
 </script>

--- a/pkg/sbomscanner-ui-ext/formatters/__tests__/IdentifiedCVEsPercentageCell.spec.ts
+++ b/pkg/sbomscanner-ui-ext/formatters/__tests__/IdentifiedCVEsPercentageCell.spec.ts
@@ -1,24 +1,32 @@
 import { shallowMount } from '@vue/test-utils';
 import IdentifiedCVEsPercentageCell from '../IdentifiedCVEsPercentageCell.vue';
-import AmountBarBySeverity from '../../components/common/AmountBarBySeverity.vue';
+import VulnerabilityHoverCell from '@sbomscanner-ui-ext/components/common/VulnerabilityHoverCell.vue';
 
 describe('IdentifiedCVEsPercentageCell.vue', () => {
-  it('should render IdentifiedCVEsPercentageCell and pass the value prop and isCollapsed=true', () => {
+  it('should render VulnerabilityHoverCell and pass the correctly formatted props', () => {
     const mockValue = {
-      critical: 5,
-      high:     10,
-      medium:   1,
-      low:      0,
-      unknown:  3
+      cveAmount: {
+        critical: 5,
+        high:     10,
+        medium:   1,
+        low:      0,
+        unknown:  3
+      },
+      total: 19,
+      link: '/c/local/explorer/apps.deployment/cattle-fleet-system/gitjob#affectingCVEs'
     };
 
-    const wrapper = shallowMount(IdentifiedCVEsPercentageCell, { props: { value: mockValue } });
+    const wrapper = shallowMount(IdentifiedCVEsPercentageCell, {
+      propsData: {
+        value: mockValue
+      },
+    });
 
-    const amountBarComponent = wrapper.findComponent(AmountBarBySeverity);
+    const hoverCellComponent = wrapper.findComponent(VulnerabilityHoverCell);
 
-    expect(amountBarComponent.exists()).toBe(true);
-
-    expect(amountBarComponent.props('cveAmount')).toEqual(mockValue);
-    expect(amountBarComponent.props('isCollapsed')).toBe(true);
+    expect(hoverCellComponent.exists()).toBe(true);
+    expect(hoverCellComponent.props('cveAmount')).toEqual(mockValue.cveAmount);
+    expect(hoverCellComponent.props('viewAllLink')).toBe(mockValue.link);
+    expect(hoverCellComponent.props('headerTitle')).toBe('19 %imageScanner.images.listTable.headers.vulnerabilities%');
   });
 });


### PR DESCRIPTION

<img width="1897" height="903" alt="Screenshot 2026-02-11 at 8 24 28 AM" src="https://github.com/user-attachments/assets/994b95d7-55b3-4cd1-8428-dae243e17713" />


Changes:

Component Integration: Replaced AmountBarBySeverity in IdentifiedCVEsPercentageCell with VulnerabilityHoverCell.

Data Refactoring: Refactored preprocessData() in ImageTableSet.vue to process data. It now calculates the total vulnerabilities inline and packages the counts, total, and dynamic routing links into a single cveSummary object.

Dynamic Routing: Implemented logic to dynamically generate the "View all" link in the hover popup (e.g., directing to #affectingCVEs when in the Workload context).

Test Coverage: Updated ImageTableSet.spec.ts and IdentifiedCVEsPercentageCell.spec.ts to accommodate the new data structures.

How to Test:

Navigate to the Image Overview or Workload details page, and check the 'Group by repository' checkbox.

Hover over the vulnerability bar in the table.

Verify that the detailed breakdown popup appears correctly.

Verify that the total number of vulnerabilities in the popup header is accurate.

(If applicable) Click the "View all" link and ensure it routes to the correct destination.