### PR TITLE
#414 [Feat] Workload tab in Image details page with CRD structure

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/common/WorkloadTableSet.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/WorkloadTableSet.vue
@@ -100,7 +100,7 @@ export default {
   },
 
   fetch() {
-    this.workloads.forEach((wl) => {
+    Object.values(this.workloads).forEach((wl) => {
       const typeOption = { label: wl.type, value: wl.type };
 
       if (!this.filterTypeOptions.some((opt) => opt.value === typeOption.value)) {

--- a/pkg/sbomscanner-ui-ext/config/sbomscanner.ts
+++ b/pkg/sbomscanner-ui-ext/config/sbomscanner.ts
@@ -55,6 +55,7 @@ export function init($plugin: any, store: any) {
   weightType(PAGE.IMAGES, 97, true);
   // weightType(PAGE.VULNERABILITIES, 96, true);
   weightType(PAGE.VEX_MANAGEMENT, 95, true);
+  weightType(RESOURCE.REGISTRY, 96, true);
 
   basicType([
     PAGE.DASHBOARD,

--- a/pkg/sbomscanner-ui-ext/config/table-headers.ts
+++ b/pkg/sbomscanner-ui-ext/config/table-headers.ts
@@ -618,7 +618,7 @@ export const WORKLOADS_TABLE = [
   {
     name:      'workloadName',
     labelKey:  'imageScanner.workloads.table.headers.workloadName',
-    value:     'workloadName',
+    value:     'name',
     formatter: 'WorkloadNameCell',
     sort:      'workloadName',
     width:     200,
@@ -652,9 +652,9 @@ export const WORKLOADS_TABLE = [
   {
     name:      'severity',
     labelKey:  'imageScanner.workloads.table.headers.severity',
-    value:     'severity',
+    value:     'summary',
     formatter: 'IdentifiedCVEsCell',
-    sort:      ['severity.critical','severity.high','severity.medium','severity.low','severity.unknown'],
+    sort:      ['summary.critical','summary.high','summary.medium','summary.low','summary.unknown'],
     width:     300,
   },
 ];

--- a/pkg/sbomscanner-ui-ext/formatters/AffectingCVEsCell.vue
+++ b/pkg/sbomscanner-ui-ext/formatters/AffectingCVEsCell.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="workload-affecting-cves-cell">
-        <router-link :to="row.workloadName">{{ affectingCVEs }}</router-link>
+        <router-link :to="affectingCVEsLink">{{ affectingCVEs }}</router-link>
     </div>
 </template>
 <script>
+import { getWorkloadLink } from '@sbomscanner-ui-ext/utils/app';
 export default {
   name:  'AffectingCVEsCell',
   props: {
@@ -15,6 +16,9 @@ export default {
   computed: {
     affectingCVEs() {
       return this.row.affectingCVEs || 0;
+    },
+    affectingCVEsLink() {
+      return getWorkloadLink(this.row, this.$route.params.cluster, 'vulnerabilities');
     }
   }
 };

--- a/pkg/sbomscanner-ui-ext/formatters/ImagesUsedCell.vue
+++ b/pkg/sbomscanner-ui-ext/formatters/ImagesUsedCell.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="images-used-cell">
-    <router-link :to="row.workloadName">{{ imagesUsed }}</router-link>
+    <router-link :to="imagesUsedLink">{{ imagesUsed }}</router-link>
   </div>
 </template>
 <script>
+import { getWorkloadLink } from '@sbomscanner-ui-ext/utils/app';
 export default {
   name: 'ImagesUsedCell',
   props: {
@@ -15,6 +16,9 @@ export default {
   computed: {
     imagesUsed() {
       return this.row.imagesUsed || 0;
+    },
+    imagesUsedLink() {
+      return getWorkloadLink(this.row, this.$route.params.cluster, 'vulnerabilities');
     }
   }
 };

--- a/pkg/sbomscanner-ui-ext/formatters/WorkloadNameCell.vue
+++ b/pkg/sbomscanner-ui-ext/formatters/WorkloadNameCell.vue
@@ -1,16 +1,26 @@
 <template>
     <div class="workload-name-cell">
-        <router-link :to="value">{{ value }}</router-link>
+        <router-link :to="workloadLink">{{ value }}</router-link>
     </div>
 </template>
 <script>
+import { getWorkloadLink } from '@sbomscanner-ui-ext/utils/app';
 export default {
   name:  'WorkloadNameCell',
   props: {
     value: {
       type:     String,
       required: true
+    },
+    row: {
+      type:     Object,
+      required: true
     }
   },
+  computed: {
+    workloadLink() {
+      return getWorkloadLink(this.row, this.$route.params.cluster);
+    }
+  }
 };
 </script>

--- a/pkg/sbomscanner-ui-ext/pages/c/_cluster/sbomscanner/ImageOverview.vue
+++ b/pkg/sbomscanner-ui-ext/pages/c/_cluster/sbomscanner/ImageOverview.vue
@@ -125,57 +125,6 @@ export default {
         }, { root: true });
       }
     },
-    preprocessData(vulReports) {
-      const severityKeys = ['critical', 'high', 'medium', 'low', 'unknown'];
-      const repoMap = new Map();
-
-      vulReports.forEach((report) => {
-        let repoRec = {};
-        const mapKey = `${ report.imageMetadata.repository },${ report.imageMetadata.registry }`;
-        const currImageScanResult = {};
-
-        for (const key of severityKeys) {
-          currImageScanResult[key] = report.report.summary[key];
-        }
-        if (repoMap.has(mapKey)) {
-          const currRepo = repoMap.get(mapKey);
-
-          for (const key of severityKeys) {
-            currRepo.cveCntByRepo[key] += report.report.summary[key];
-          }
-          currRepo.images.push(
-            {
-              id:             report.id,
-              imageMetadata:  report.imageMetadata,
-              metadata:       { name: report.metadata.name },
-              imageReference: constructImageName(report.imageMetadata),
-              scanResult:     currImageScanResult,
-            }
-          );
-          repoMap.set(mapKey, currRepo);
-        } else {
-          repoRec = {
-            id:           mapKey,
-            repository:   report.imageMetadata.repository,
-            registry:     report.imageMetadata.registry,
-            metadata:     { namespace: report.metadata.namespace },
-            cveCntByRepo: { ...currImageScanResult },
-            images:       [
-              {
-                id:             report.id,
-                imageMetadata:  report.imageMetadata,
-                metadata:       { name: report.metadata.name },
-                imageReference: constructImageName(report.imageMetadata),
-                scanResult:     currImageScanResult,
-              }
-            ]
-          };
-          repoMap.set(mapKey, repoRec);
-        }
-      });
-
-      return Array.from(repoMap.values());
-    },
   },
 };
 

--- a/pkg/sbomscanner-ui-ext/utils/app.ts
+++ b/pkg/sbomscanner-ui-ext/utils/app.ts
@@ -1,3 +1,4 @@
+import { POD, WORKLOAD_TYPES, INGRESS, SERVICE, WORKLOAD_TYPE_TO_KIND_MAPPING } from '@shell/config/types';
 // Utility method to decode base64 strings
 export function decodeBase64(str: string) {
   try {
@@ -31,4 +32,22 @@ export function trimIntervalSuffix(interval: string): string {
   }
 
   return result || interval;
+}
+
+export function getWorkloadLink(row: any, cluster: string, hash?: string): string {
+  const namespace = row.namespace || 'default';
+  const baseUrl = `/c/${cluster}/explorer`;
+
+  const routeMap = {
+    Pod:                                                          POD,
+    [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.CRON_JOB]]:     WORKLOAD_TYPES.CRON_JOB,
+    [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.DAEMON_SET]]:   WORKLOAD_TYPES.DAEMON_SET,
+    Deployment:                                                   WORKLOAD_TYPES.DEPLOYMENT,
+    [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.JOB]]:          WORKLOAD_TYPES.JOB,
+    [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.STATEFUL_SET]]: WORKLOAD_TYPES.STATEFUL_SET,
+    Ingress:                                                      INGRESS,
+    Service:                                                      SERVICE
+  };
+
+  return `${baseUrl}/${routeMap[row.type] || ''}/${namespace}/${row.name}${hash ? `#${hash}` : ''}`;
 }


### PR DESCRIPTION
Got the link on the images used and affacting CVEs, we temporarily use `#vulnerabilities` to redirect to the workload page's vulnerabilities tab. 
The sub-tabs cannot be reached directly by hash in Rancher UI