### PR TITLE
UI: fix badge-state font size per Figma specs (#499)

### DIFF
--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
@@ -745,12 +745,12 @@ export default {
     align-items: center;
     gap: 8px;
     font-size: 24px;
-    font-weight: 500;
+    font-weight: 400;
     margin: 0;
   }
 
   .badge-state {
-    font-size: 12px;
+    font-size: initial;
     line-height: normal;
     padding: 2px 8px;
     border-radius: 20px;


### PR DESCRIPTION
Set .badge-state font-size to initial to match the Figma design