### PR TITLE
[feat] Redirection solution for cluster scan result [fix #531]

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/ImageDetails.vue
+++ b/pkg/sbomscanner-ui-ext/components/ImageDetails.vue
@@ -394,6 +394,7 @@ export default {
     parseWorkloadTableData(workloads) {
       return workloads.map((workload) => {
         return {
+          reportName: workload.id,
           name:       workload.metadata.ownerReferences ? workload.metadata.ownerReferences[0]?.name : '',
           type:       workload.metadata.ownerReferences ? workload.metadata.ownerReferences[0]?.kind : '',
           namespace:  workload.metadata.namespace,

--- a/pkg/sbomscanner-ui-ext/components/__tests__/ImageDetails.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/__tests__/ImageDetails.spec.ts
@@ -490,6 +490,55 @@ describe('ImageDetails.vue', () => {
     expect(out[0].summary).toEqual({ high: 2 });
   });
 
+  it('parseWorkloadTableData handles missing ownerReferences and computes imagesUsed', () => {
+    wrapper.vm.images = [
+      { imageMetadata: { repository: 'nginx', tag: 'latest' } },
+      { imageMetadata: { repository: 'nginx', tag: 'latest' } },
+      { imageMetadata: { repository: 'busybox', tag: '1.0' } },
+    ];
+
+    const workloads = [
+      {
+        metadata: { namespace: 'default' },
+        spec:     { containers: [{ imageRef: { repository: 'nginx', tag: 'latest' } }] },
+        summary:  { high: 2 },
+      }
+    ];
+
+    const out = wrapper.vm.parseWorkloadTableData(workloads);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('');
+    expect(out[0].type).toBe('');
+    expect(out[0].namespace).toBe('default');
+    expect(out[0].imagesUsed).toBe(2);
+    expect(out[0].summary).toEqual({ high: 2 });
+  });
+
+  it('parseWorkloadTableData correctly maps workload.id to reportName', () => {
+    wrapper.vm.images = [];
+
+    const workloads = [
+      {
+        id: 'cattle-sbomscanner-system/cluster-5a736a4b-acbe-41e9-97a6-f326bf46cac6',
+        metadata: {
+          namespace: 'cattle-sbomscanner-system',
+          ownerReferences: [{ name: 'rancher-sbomscanner-cnpg-cluster', kind: 'Cluster' }]
+        },
+        spec: { containers: [] },
+        summary: { critical: 4, high: 6 },
+      }
+    ];
+
+    const out = wrapper.vm.parseWorkloadTableData(workloads);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].reportName).toBe('cattle-sbomscanner-system/cluster-5a736a4b-acbe-41e9-97a6-f326bf46cac6');
+    expect(out[0].name).toBe('rancher-sbomscanner-cnpg-cluster');
+    expect(out[0].type).toBe('Cluster');
+    expect(out[0].namespace).toBe('cattle-sbomscanner-system');
+  });
+
   it('calls loadImageData without errors', async() => {
     mockStore.getters['cluster/all']
       .mockReturnValueOnce(() => [{ metadata: { name: 'test-image' }, imageMetadata: {} }])

--- a/pkg/sbomscanner-ui-ext/utils/__tests__/app.spec.ts
+++ b/pkg/sbomscanner-ui-ext/utils/__tests__/app.spec.ts
@@ -234,4 +234,19 @@ describe('getWorkloadLink', () => {
 
     expect(result).toBe('/c/local/explorer/cronjob/batch/nightly');
   });
+
+  it('returns the correct direct report link when the workload kind is Cluster', () => {
+    const mockRow = {
+      type:       'Cluster',
+      reportName: 'cattle-sbomscanner-system/cluster-5a736a4b-acbe-41e9-97a6-f326bf46cac6',
+      namespace:  'default',
+      name:       'ignored-name'
+    };
+
+    const clusterId = 'local';
+    const link = getWorkloadLink(mockRow, clusterId);
+
+    // RESOURCE.WORKLOAD resolves to 'storage.sbomscanner.kubewarden.io.workloadscanreport'
+    expect(link).toBe('/c/local/explorer/storage.sbomscanner.kubewarden.io.workloadscanreport/cattle-sbomscanner-system/cluster-5a736a4b-acbe-41e9-97a6-f326bf46cac6');
+  });
 });

--- a/pkg/sbomscanner-ui-ext/utils/app.ts
+++ b/pkg/sbomscanner-ui-ext/utils/app.ts
@@ -1,4 +1,6 @@
 import { POD, WORKLOAD_TYPES, INGRESS, SERVICE, WORKLOAD_TYPE_TO_KIND_MAPPING } from '@shell/config/types';
+import { RESOURCE } from '@sbomscanner-ui-ext/types';
+
 // Utility method to decode base64 strings
 export function decodeBase64(str: string) {
   try {
@@ -46,8 +48,13 @@ export function getWorkloadLink(row: any, cluster: string, hash?: string, query?
     [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.JOB]]:          WORKLOAD_TYPES.JOB,
     [WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.STATEFUL_SET]]: WORKLOAD_TYPES.STATEFUL_SET,
     Ingress:                                                      INGRESS,
-    Service:                                                      SERVICE
+    Service:                                                      SERVICE,
+    Cluster:                                                      RESOURCE.WORKLOAD
   };
+
+  if(row.type?.toLowerCase() === 'cluster') {
+    return `${baseUrl}/${routeMap[row.type] || ''}/${row.reportName}`;
+  }
 
   const queryString = query ? `?${query}` : '';
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #531 

* Updated `parseWorkloadTableData` in `ImageDetails.vue` to map `workload.id` to a new `reportName` property.
* Modified `getWorkloadLink` in `app.ts` to intercept workloads with the `Cluster` kind and construct the URL to route it to the `storage.sbomscanner.kubewarden.io.workloadscanreport` page.
* Added corresponding unit tests in `app.spec.ts` and `ImageDetails.spec.ts` to cover the new logic.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

1. Navigate to the Image Details page -> workload tab
2. Locate a workload type is Cluster
3. Click the workload link and verify that it correctly redirects to "More resources -> storage.sbomscanner.kubewarden.io -> WorkloadScanReports -> [Report ID] "

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
