### PR TITLE
#539 Replace instances of fragmented translations using RichTranslation component

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/WorkloadVulnerabilities.vue
+++ b/pkg/sbomscanner-ui-ext/components/WorkloadVulnerabilities.vue
@@ -1,5 +1,5 @@
 <script>
-import { Banner } from '@components/Banner';
+import WorkloadBanner from './common/WorkloadBanner.vue';
 import {
   createCsvRows,
   pushCsvRow,
@@ -21,11 +21,11 @@ import VulnerabilityTableSet from './common/VulnerabilityTableSet.vue';
 export default {
   name:       'WorkloadVulnerabilitiesGrid',
   components: {
+    WorkloadBanner,
     VulnerabilityTableSet,
     ImageTableSet,
     Tab,
     Tabbed,
-    Banner,
     DownloadFullReportBtn,
   },
   data() {
@@ -325,19 +325,7 @@ export default {
 
 <template>
   <div class="vul-header">
-    <Banner color="info" class="vul-banner">
-      <span>{{ t('imageScanner.general.workloadBanner.text1') }}</span>
-      <a href="/" target="_blank" rel="noopener noreferrer" class="text-underline">{{ t('imageScanner.general.workloadBanner.product') }}</a>
-      <span>, {{ t('imageScanner.general.workloadBanner.text2') }}</span>
-      <a
-        href="/"
-        class="text-underline"
-        rel="noopener noreferrer"
-        target="_blank">
-        {{ t('imageScanner.general.workloadBanner.documentation') }}
-        <i class="icon icon-external-link icon-underline"></i>
-      </a>
-    </Banner>
+    <WorkloadBanner />
     <!-- Download Full Report Dropdown -->
     <DownloadFullReportBtn
       class="vul-report-menu-btn"
@@ -378,30 +366,12 @@ export default {
 
 
 <style lang="scss" scoped>
-.text-underline {
-  color: var(--body-text);
-  border-bottom: 0.65px solid var(--body-text);
-  &:hover {
-    text-decoration: none;
-  }
-}
-.icon-underline {
-  font-size: 10px;
-}
 .vul-header {
   display: flex;
   height: 40px;
   justify-content: center;
   align-items: center;
   gap: -1px;
-  .vul-banner {
-    display: flex;
-    padding: 10px 16px;
-    align-items: center;
-    gap: 4px;
-    flex: 1 0 0;
-    padding-left: 0;
-  }
 }
 .workload-tabs {
   margin-top: 24px;

--- a/pkg/sbomscanner-ui-ext/components/common/AmountBarBySeverityPoppedDetail.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/AmountBarBySeverityPoppedDetail.vue
@@ -53,10 +53,7 @@
         </div>
 
         <div class="footer">
-          {{ t('imageScanner.general.cvesPanel.text1') }}
-          <a href="/" target="_blank" rel="noopener noreferrer" class="provider-name">
-            {{ footerProvider }}
-          </a>
+          <CvesPanelFooter />
         </div>
       </div>
     </div>
@@ -65,10 +62,11 @@
 
 <script>
 import AmountBarBySeverity from './AmountBarBySeverity.vue';
+import CvesPanelFooter from './CvesPanelFooter.vue';
 
 export default {
   name:       'AmountBarBySeverityPoppedDetail',
-  components: { AmountBarBySeverity },
+  components: { AmountBarBySeverity, CvesPanelFooter },
   props: {
     cveAmount: {
       type:     Object,
@@ -84,10 +82,6 @@ export default {
     viewAllLink: {
       type:    String,
       default: ''
-    },
-    footerProvider: {
-      type:    String,
-      default: 'SBOMScanner'
     },
   },
   data() {
@@ -291,19 +285,6 @@ $gap-size: 10px;
     width: 35px;
     text-align: right;
     color: var(--label-secondary);
-  }
-}
-
-.footer {
-  margin-top: 12px;
-  text-align: right;
-  font-size: 14px;
-  line-height: 140%;
-  color: var(--label-secondary);
-
-  .provider-name {
-    color: var(--label-secondary);
-    text-decoration: underline;
   }
 }
 

--- a/pkg/sbomscanner-ui-ext/components/common/AuthCreateDescription.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/AuthCreateDescription.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import RichTranslation from '@shell/components/RichTranslation.vue';
+
+defineProps<{ secretCreateUrl: string }>();
+defineEmits<{ (e: 'refresh'): void }>();
+</script>
+
+<template>
+  <div>
+    <p class="m-0 mb-5">
+      <RichTranslation :k="'imageScanner.registries.configuration.cru.authentication.createDescription1'">
+        <template #secret="{ content }">
+          <a :href="secretCreateUrl" target="_blank">{{ content }}</a>
+        </template>
+      </RichTranslation>
+    </p>
+    <p class="m-0">
+      <RichTranslation :k="'imageScanner.registries.configuration.cru.authentication.createDescription2'">
+        <template #refresh="{ content }">
+          <a href="#" @click.prevent="$emit('refresh')">{{ content }}</a>
+        </template>
+      </RichTranslation>
+    </p>
+  </div>
+</template>

--- a/pkg/sbomscanner-ui-ext/components/common/CvesPanelFooter.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/CvesPanelFooter.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import RichTranslation from '@shell/components/RichTranslation.vue';
+</script>
+
+<template>
+  <div class="footer">
+    <RichTranslation :k="'imageScanner.general.cvesPanel.text'">
+      <template #provider="{ content }">
+        <a href="/" target="_blank" rel="noopener noreferrer" class="provider-name">{{ content }}</a>
+      </template>
+    </RichTranslation>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.footer {
+  margin-top: 12px;
+  text-align: right;
+  font-size: 14px;
+  line-height: 140%;
+  color: var(--label-secondary);
+
+  .provider-name {
+    color: var(--label-secondary);
+    text-decoration: underline;
+  }
+}
+</style>

--- a/pkg/sbomscanner-ui-ext/components/common/WorkloadBanner.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/WorkloadBanner.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Banner } from '@rancher/components';
+import RichTranslation from '@shell/components/RichTranslation.vue';
+</script>
+
+<template>
+  <Banner color="info" class="vul-banner">
+    <RichTranslation :k="'imageScanner.general.workloadBanner.text'">
+      <template #product="{ content }">
+        <a href="/" target="_blank" rel="noopener noreferrer" class="text-underline">{{ content }}</a>
+      </template>
+      <template #documentation="{ content }">
+        <a href="/" class="text-underline" rel="noopener noreferrer" target="_blank">
+          {{ content }}<i class="icon icon-external-link icon-underline"></i>
+        </a>
+      </template>
+    </RichTranslation>
+  </Banner>
+</template>
+
+<style lang="scss" scoped>
+.text-underline {
+  color: var(--body-text);
+  border-bottom: 0.65px solid var(--body-text);
+  &:hover {
+    text-decoration: none;
+  }
+}
+.icon-underline {
+  font-size: 10px;
+}
+.vul-banner {
+  display: flex;
+  padding: 10px 16px;
+  align-items: center;
+  gap: 4px;
+  flex: 1 0 0;
+  padding-left: 0;
+}
+</style>

--- a/pkg/sbomscanner-ui-ext/components/common/__tests__/AmountBarBySeverityPoppedDetail.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/common/__tests__/AmountBarBySeverityPoppedDetail.spec.ts
@@ -120,12 +120,6 @@ describe('VulnerabilityHoverCell.vue', () => {
       expect(wrapper.find('.view-all').exists()).toBe(false);
     });
 
-    it('renders the footer provider name', () => {
-      const wrapper = createWrapper({ footerProvider: 'My Scanner' });
-
-      expect(wrapper.find('.provider-name').text()).toBe('My Scanner');
-    });
-
     it('renders exactly 5 severity rows with correct labels', () => {
       const wrapper = createWrapper();
       const rows = wrapper.findAll('.severity-row');

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
@@ -17,6 +17,7 @@ import { PRODUCT_NAME, PAGE, LOCAT_HOST } from '@sbomscanner-ui-ext/types';
 import { SECRET_TYPES } from '@shell/config/secret';
 import { filterUnique } from "@sbomscanner-ui-ext/utils/app";
 import { VALID_PLATFORMS, ALLOWED_VARIANTS } from '@sbomscanner-ui-ext/constants/securityConstants';
+import AuthCreateDescription from '@sbomscanner-ui-ext/components/common/AuthCreateDescription.vue';
 
 export default {
   name: 'CruRegistry',
@@ -29,6 +30,7 @@ export default {
     CruResource,
     LabeledSelect,
     Banner,
+    AuthCreateDescription,
   },
 
   mixins: [CreateEditView],
@@ -388,29 +390,10 @@ export default {
       >
         <div class="col span-12">
           <Banner color="info">
-            <div>
-              <p class="m-0 mb-5">
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_start') }}
-                <a
-                  :href="secretCreateUrl"
-                  target="_blank"
-                >
-                  {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_link') }}
-                </a>
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_end') }}
-              </p>
-
-              <p class="m-0">
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_start') }}
-                <a
-                  href="#"
-                  @click.prevent="refreshList"
-                >
-                  {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_link') }}
-                </a>
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_end') }}
-              </p>
-            </div>
+          <AuthCreateDescription
+            :secret-create-url="secretCreateUrl"
+            @refresh="refreshList"
+          />
           </Banner>
         </div>
       </div>

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
@@ -13,6 +13,7 @@ import { SBOMSCANNER_INSTALLATION_NAMESPACE, SCAN_INTERVAL_OPTIONS, SCAN_INTERVA
 import { PRODUCT_NAME, PAGE, LOCAT_HOST } from '@sbomscanner-ui-ext/types';
 import { filterUnique } from '@sbomscanner-ui-ext/utils/app';
 import { VALID_PLATFORMS, ALLOWED_VARIANTS, WORKLOAD_SCAN_DOCS_URL } from '@sbomscanner-ui-ext/constants/securityConstants';
+import AuthCreateDescription from '@sbomscanner-ui-ext/components/common/AuthCreateDescription.vue';
 
 const OS_OPTIONS = Object.keys(VALID_PLATFORMS).map((k) => ({ label: k, value: k }));
 
@@ -27,6 +28,7 @@ export default {
     LabeledSelect,
     MatchExpressions,
     Banner,
+    AuthCreateDescription,
   },
 
   mixins: [CreateEditView],
@@ -464,18 +466,10 @@ export default {
       <div v-if="value.spec.authSecret === 'create'" class="row mt-16">
         <div class="col span-12">
           <Banner color="info" class="m-0">
-            <div>
-              <p class="m-0 mb-5">
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_start') }}
-                <a :href="secretCreateUrl" target="_blank">{{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_link') }}</a>
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine1_end') }}
-              </p>
-              <p class="m-0">
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_start') }}
-                <a href="#" @click.prevent="refreshList">{{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_link') }}</a>
-                {{ t('imageScanner.registries.configuration.cru.authentication.createDescriptionLine2_end') }}
-              </p>
-            </div>
+            <AuthCreateDescription
+              :secret-create-url="secretCreateUrl"
+              @refresh="refreshList"
+            />
           </Banner>
         </div>
       </div>

--- a/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
+++ b/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
@@ -458,13 +458,9 @@ imageScanner:
     yes: Yes
     no: No
     workloadBanner:
-      text1: Data provided by
-      text2: Want to learn more about this extension? 
-      text3: Read our
-      product: SBOMScanner
-      documentation: documentation
+      text: Data provided by <product>SBOMScanner</product>, Want to learn more about this extension? Read our <documentation>documentation</documentation>
     cvesPanel:
-      text1: Provided by
+      text: Provided by <provider>SBOMScanner</provider>
 typeLabel:
   sbomscanner.kubewarden.io.registry: Registries configuration
   sbomscanner.kubewarden.io.vexhub: VEX Management

--- a/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
+++ b/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
@@ -121,12 +121,8 @@ imageScanner:
         authentication:
           label: Authentication
           create: Create a new Authentication
-          createDescriptionLine1_start: Creating a new authentication in context is not currently supported. Please
-          createDescriptionLine1_link: create a new secret
-          createDescriptionLine1_end: first.
-          createDescriptionLine2_start: Next, continue by clicking this
-          createDescriptionLine2_link: refresh
-          createDescriptionLine2_end: link to asynchronously reload the authentication list above and select the newly created secret.
+          createDescription1: Creating a new authentication in context is not currently supported. Please <secret>create a new secret</secret> first.
+          createDescription2: Next, continue by clicking this <refresh>refresh</refresh> link to asynchronously reload the authentication list above and select the newly created secret.
         scan:
           label: Scanning
           repoName: Repositories to scan


### PR DESCRIPTION
## Description

Fixes #539 

Refactor banner and footer strings in the sbomscanner-ui-ext to use the `RichTranslation` [component](https://github.com/rancher/dashboard/pull/14736) introduced in `@rancher/shell` 3.0.5, replacing the previous pattern of splitting translation strings into multiple fragmented l10n keys in order to support embedded interactive elements (links, actions, etc.).

## Test

Navigate to the following pages in a running Rancher instance with the sbomscanner extension installed:

1. Workload detail page → verify the info banner renders "Data provided by SBOMScanner, Want to learn more..." with working links
2. Any CVE popup (hover over a severity bar) → verify the footer renders "Provided by SBOMScanner" with correct styling
3. Registry edit page → Authentication → "Create a new Authentication" → verify both description lines render with working "create a new secret" link and functional "refresh" link
4. Workload Scan Configuration edit page → same authentication section → same verification

## Additional Information

### Tradeoff

### Potential improvement
