### PR TITLE
[feat] replace secret selector and creation banner with SelectOrCreateAuthSecret

### DIFF
--- a/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.registry.spec.ts
+++ b/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.registry.spec.ts
@@ -32,6 +32,7 @@ const stubs = {
   LabeledInput:      true,
   Banner:            { name: 'Banner', template: '<div><slot /></div>' },
   LabeledSelect:     LabeledSelectStub,
+  SelectOrCreateAuthSecret: { name: 'SelectOrCreateAuthSecret', template: '<div class="select-or-create-auth-secret"></div>' },
   Checkbox:          {
     name: 'Checkbox', template: '<input type="checkbox" :checked="value" @change="$emit(\'update:value\', $event.target.checked)" />', props: ['value', 'label', 'tooltip']
   },
@@ -111,6 +112,7 @@ describe('CruRegistry', () => {
       expect(spec.scanInterval).toBeUndefined();
       expect(spec.caBundle).toBe('');
       expect(spec.insecure).toBe(false);
+      expect(wrapper.vm.secretCreateHook).toBeNull();
     });
   });
 
@@ -128,7 +130,6 @@ describe('CruRegistry', () => {
       await flushPromises();
 
       expect(dispatch).toHaveBeenCalledWith('cluster/findAll', { type: SECRET });
-
       expect(wrapper.vm.allSecrets).toStrictEqual(mockSecrets);
     });
   });
@@ -183,41 +184,33 @@ describe('CruRegistry', () => {
     });
   });
 
-  describe('computed: options (Auth Secrets)', () => {
-    beforeEach(async() => {
+  describe('computed: safeRegistryUrl', () => {
+    beforeEach(() => {
       wrapper = createWrapper({});
-      wrapper.vm.allSecrets = mockSecrets;
-      await wrapper.vm.$nextTick();
     });
 
-    it('should return default options if no secrets are loaded', async() => {
-      wrapper.vm.allSecrets = null;
-      await wrapper.vm.$nextTick();
-      const options = wrapper.vm.options;
+    it('should return empty string if URI is empty or undefined', () => {
+      wrapper.vm.value.spec.uri = '';
+      expect(wrapper.vm.safeRegistryUrl).toBe('');
 
-      expect(options.length).toBe(3);
+      wrapper.vm.value.spec.uri = undefined;
+      expect(wrapper.vm.safeRegistryUrl).toBe('');
     });
 
-    it('should filter secrets by namespace (default) and type (docker-json)', () => {
-      const options = wrapper.vm.options;
+    it('should prepend https:// if no protocol is present', () => {
+      wrapper.vm.value.spec.uri = 'ghcr.io';
+      expect(wrapper.vm.safeRegistryUrl).toBe('https://ghcr.io');
 
-      expect(options.length).toBe(4);
-      expect(options[3].label).toBe('secret-1');
+      wrapper.vm.value.spec.uri = 'docker.io';
+      expect(wrapper.vm.safeRegistryUrl).toBe('https://docker.io');
     });
 
-    it('should update options when namespace changes', async() => {
-      await wrapper.setProps({
-        value: {
-          ...defaultProps.value,
-          metadata: { namespace: 'other' },
-          spec:     wrapper.vm.value.spec,
-        },
-      });
-      await wrapper.vm.$nextTick();
-      const options = wrapper.vm.options;
+    it('should not modify the URI if a protocol is already present', () => {
+      wrapper.vm.value.spec.uri = 'https://ghcr.io';
+      expect(wrapper.vm.safeRegistryUrl).toBe('https://ghcr.io');
 
-      expect(options.length).toBe(4);
-      expect(options[3].label).toBe('secret-2');
+      wrapper.vm.value.spec.uri = 'http://localhost:5000';
+      expect(wrapper.vm.safeRegistryUrl).toBe('http://localhost:5000');
     });
   });
 
@@ -260,15 +253,6 @@ describe('CruRegistry', () => {
       const newValue = deepClone(validValue);
 
       newValue.spec.uri = ' ';
-      await wrapper.setProps({ value: newValue });
-      await wrapper.vm.$nextTick();
-      expect(wrapper.vm.validationPassed).toBe(false);
-    });
-
-    it('should fail if authSecret is "create"', async() => {
-      const newValue = deepClone(validValue);
-
-      newValue.spec.authSecret = 'create';
       await wrapper.setProps({ value: newValue });
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.validationPassed).toBe(false);
@@ -359,6 +343,19 @@ describe('CruRegistry', () => {
     });
   });
 
+  describe('methods: SelectOrCreateAuthSecret Hook', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({});
+    });
+
+    it('registerSecretHook should set the secretCreateHook', () => {
+      const mockHook = jest.fn();
+
+      wrapper.vm.registerSecretHook(mockHook);
+      expect(wrapper.vm.secretCreateHook).toBe(mockHook);
+    });
+  });
+
   describe('methods: finish & error handling', () => {
     const save = jest.fn();
 
@@ -381,7 +378,20 @@ describe('CruRegistry', () => {
       });
     });
 
-    it('should call save and route on success', async() => {
+    it('should execute the secretCreateHook if registered before saving', async() => {
+      const mockHook = jest.fn().mockResolvedValue(true);
+
+      wrapper.vm.registerSecretHook(mockHook);
+      save.mockResolvedValue({});
+
+      await wrapper.vm.finish();
+
+      expect(mockHook).toHaveBeenCalled();
+      expect(save).toHaveBeenCalled();
+      expect(mockRouter.push).toHaveBeenCalled();
+    });
+
+    it('should call save and route on success when no hook is present', async() => {
       save.mockResolvedValue({});
       await wrapper.vm.finish();
       expect(save).toHaveBeenCalled();
@@ -423,32 +433,19 @@ describe('CruRegistry', () => {
       expect(mockRouter.push).not.toHaveBeenCalled();
       expect(wrapper.vm.errors).toEqual([error]);
     });
-  });
 
-  describe('methods: refreshList', () => {
-    it('should set loading state and re-fetch secrets', async() => {
-      const newMockSecret = [{ metadata: { name: 'new-secret', namespace: 'default' }, _type: SECRET_TYPES.DOCKER_JSON }];
-      const dispatch = jest.fn().mockResolvedValue(newMockSecret);
-      const specificStore = { ...mockStore, dispatch };
+    it('should set errors and not route on secretCreateHook failure', async() => {
+      const error = new Error('Hook failed');
+      const mockHook = jest.fn().mockRejectedValue(error);
 
-      wrapper = createWrapper({}, specificStore);
+      wrapper.vm.registerSecretHook(mockHook);
 
-      if (wrapper.vm.$options.fetch) {
-        await wrapper.vm.$options.fetch.call(wrapper.vm);
-      }
-      await flushPromises();
-      dispatch.mockClear();
+      await wrapper.vm.finish();
 
-      expect(wrapper.vm.authLoading).toBe(false);
-      const promise = wrapper.vm.refreshList();
-
-      expect(wrapper.vm.authLoading).toBe(true);
-
-      await promise;
-
-      expect(dispatch).toHaveBeenCalledWith('cluster/findAll', { type: SECRET });
-      expect(wrapper.vm.allSecrets).toEqual(newMockSecret);
-      expect(wrapper.vm.authLoading).toBe(false);
+      expect(mockHook).toHaveBeenCalled();
+      expect(save).not.toHaveBeenCalled();
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(wrapper.vm.errors).toEqual([error]);
     });
   });
 
@@ -459,29 +456,17 @@ describe('CruRegistry', () => {
 
       const mockError = { message: 'admission webhook denied the request' };
 
-      // Simulate CruResource emitting an error event (like when ResourceYaml fails to save)
       cruResource.vm.$emit('error', mockError);
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.errors).toEqual([mockError]);
     });
 
-    it('should show info banner when authSecret is "create"', async() => {
+    it('should render the SelectOrCreateAuthSecret component', () => {
       wrapper = createWrapper({});
-      await wrapper.setProps({ value: { ...wrapper.vm.value, spec: { ...wrapper.vm.value.spec, authSecret: 'create' } } });
-      await wrapper.vm.$nextTick();
-      const banner = wrapper.findComponent({ name: 'Banner' });
+      const secretComponent = wrapper.findComponent({ name: 'SelectOrCreateAuthSecret' });
 
-      expect(banner.exists()).toBe(true);
-    });
-
-    it('should NOT show info banner when authSecret is not "create"', async() => {
-      wrapper = createWrapper({});
-      await wrapper.setProps({ value: { ...wrapper.vm.value, spec: { ...wrapper.vm.value.spec, authSecret: 'my-secret' } } });
-      await wrapper.vm.$nextTick();
-      const banner = wrapper.findComponent({ name: 'Banner' });
-
-      expect(banner.exists()).toBe(false);
+      expect(secretComponent.exists()).toBe(true);
     });
 
     it('should mark repositories as required when type is NO_CATALOG', async() => {

--- a/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
+++ b/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
@@ -1,9 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 import CruWorkloadScanConfiguration from '../sbomscanner.kubewarden.io.workloadscanconfiguration.vue';
 import { SCAN_INTERVALS } from '@sbomscanner-ui-ext/constants';
-import { SECRET_TYPES } from '@shell/config/secret';
 
-// 1. We MUST mock the Rancher constants so CATALOG.APP evaluates correctly in the try/catch block
+
 jest.mock('@shell/config/types', () => ({
   CATALOG: { APP: 'catalog.cattle.io.app' },
   NAMESPACE: 'namespace',
@@ -97,7 +96,8 @@ describe('CruWorkloadScanConfiguration.vue', () => {
           Checkbox: true,
           MatchExpressions: true,
           Banner: true,
-          FileSelector: true
+          FileSelector: true,
+          SelectOrCreateAuthSecret: true
         }
       }
     });
@@ -111,6 +111,7 @@ describe('CruWorkloadScanConfiguration.vue', () => {
       wrapper = createWrapper({ enabled: true });
       expect(wrapper.exists()).toBe(true);
       expect(wrapper.vm.savedEnabledState).toBe(true);
+      expect(wrapper.vm.secretCreateHook).toBeNull();
     });
 
     it('does not change savedEnabledState when the checkbox is toggled', async () => {
@@ -172,20 +173,6 @@ describe('CruWorkloadScanConfiguration.vue', () => {
       expect(wrapper.vm.value.spec.artifactsNamespace).toBe('cattle-sbomscanner-system');
     });
 
-    it('updates default artifactsNamespace to dynamic installation namespace if it was cleared to an empty string', async () => {
-      wrapper = createWrapper({}, 'create', {});
-      wrapper.vm.initDefaults();
-
-      // Simulating a user clearing out the field before fetch completes
-      wrapper.vm.value.spec.artifactsNamespace = '';
-
-      // Run fetch to dynamically discover app
-      await wrapper.vm.$options.fetch.call(wrapper.vm);
-
-      // Should override the empty string with the discovered installation namespace
-      expect(wrapper.vm.value.spec.artifactsNamespace).toBe('');
-    });
-
     it('does NOT update artifactsNamespace on fetch if user has already modified it to a custom value', async () => {
       wrapper = createWrapper({}, 'create', {});
       wrapper.vm.initDefaults();
@@ -226,29 +213,6 @@ describe('CruWorkloadScanConfiguration.vue', () => {
       });
     });
 
-    describe('authOptions', () => {
-      it('filters secrets by type DOCKER_JSON and the dynamically fetched installation namespace and uses secret name as label', async () => {
-        wrapper = createWrapper({});
-        await wrapper.vm.$options.fetch.call(wrapper.vm);
-
-        wrapper.vm.allSecrets = [
-          { metadata: { name: 'wrong-ns', namespace: 'default' }, _type: SECRET_TYPES.DOCKER_JSON },
-          { metadata: { name: 'correct-secret-name', namespace: 'custom-sbom-namespace' }, _type: SECRET_TYPES.DOCKER_JSON },
-        ];
-
-        expect(wrapper.vm.authOptions.length).toBe(4); // 3 defaults + 1 valid secret
-        expect(wrapper.vm.authOptions[3].value).toBe('correct-secret-name');
-        expect(wrapper.vm.authOptions[3].label).toBe('correct-secret-name'); // Verifying namespace prefix is dropped
-      });
-    });
-
-    describe('secretCreateUrl', () => {
-      it('generates secretCreateUrl correctly', () => {
-        wrapper = createWrapper();
-        expect(wrapper.vm.secretCreateUrl).toContain('explorer/secret/create?namespace=');
-      });
-    });
-
     describe('matchExpressions setter', () => {
       it('deletes matchExpressions if set to null or empty', () => {
         wrapper = createWrapper({ namespaceSelector: { matchExpressions: [{ key: 'a', operator: 'In', values: ['b'] }] } });
@@ -263,18 +227,6 @@ describe('CruWorkloadScanConfiguration.vue', () => {
         wrapper.vm.selectedScanInterval = '12h';
         expect(wrapper.vm.value.spec.scanInterval).toBe('12h');
       });
-    });
-  });
-
-  describe('Validation', () => {
-    it('passes validation when a valid secret is selected or left blank', () => {
-      wrapper = createWrapper({ authSecret: 'my-secret' });
-      expect(wrapper.vm.validationPassed).toBe(true);
-    });
-
-    it('fails validation when authSecret is set to "create"', () => {
-      wrapper = createWrapper({ authSecret: 'create' });
-      expect(wrapper.vm.validationPassed).toBe(false);
     });
   });
 
@@ -363,15 +315,16 @@ describe('CruWorkloadScanConfiguration.vue', () => {
     });
   });
 
-  describe('Other Methods', () => {
-    it('populates errors if refreshList fails', async () => {
+  describe('SelectOrCreateAuthSecret Integration', () => {
+    it('registerSecretHook should set the secretCreateHook', () => {
       wrapper = createWrapper();
-      wrapper.vm.$store.dispatch = jest.fn().mockRejectedValue(new Error('Refresh failed'));
-      await wrapper.vm.refreshList();
-      expect(wrapper.vm.errors).toEqual([new Error('Refresh failed')]);
-      expect(wrapper.vm.authLoading).toBe(false);
+      const mockHook = jest.fn();
+      wrapper.vm.registerSecretHook(mockHook);
+      expect(wrapper.vm.secretCreateHook).toBe(mockHook);
     });
+  });
 
+  describe('Other Methods', () => {
     it('sets caBundle on onFileSelected', () => {
       wrapper = createWrapper();
       wrapper.vm.onFileSelected('cert-data');
@@ -391,6 +344,32 @@ describe('CruWorkloadScanConfiguration.vue', () => {
       expect(preventDefault).toHaveBeenCalled();
       expect(wrapper.vm.save).toHaveBeenCalled();
       expect(wrapper.vm.savedEnabledState).toBe(false);
+    });
+
+    it('executes secretCreateHook if present before saving', async () => {
+      wrapper = createWrapper({ enabled: true });
+      const mockHook = jest.fn().mockResolvedValue(true);
+      wrapper.vm.registerSecretHook(mockHook);
+      wrapper.vm.save = jest.fn().mockResolvedValue(true);
+
+      await wrapper.vm.finish();
+
+      expect(mockHook).toHaveBeenCalled();
+      expect(wrapper.vm.save).toHaveBeenCalled();
+    });
+
+    it('does not proceed to save if secretCreateHook throws an error', async () => {
+      wrapper = createWrapper({ enabled: true });
+      const error = new Error('Secret creation failed');
+      const mockHook = jest.fn().mockRejectedValue(error);
+      wrapper.vm.registerSecretHook(mockHook);
+      wrapper.vm.save = jest.fn();
+
+      await wrapper.vm.finish();
+
+      expect(mockHook).toHaveBeenCalled();
+      expect(wrapper.vm.save).not.toHaveBeenCalled();
+      expect(wrapper.vm.errors).toEqual([error]);
     });
 
     it('calls finish without event safely', async () => {

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.registry.vue
@@ -13,11 +13,10 @@ import {
   REGISTRY_TYPE_OPTIONS,
   SCAN_INTERVAL_OPTIONS, SCAN_INTERVALS, DEFAULT_REG_URI
 } from '@sbomscanner-ui-ext/constants';
-import { PRODUCT_NAME, PAGE, LOCAT_HOST } from '@sbomscanner-ui-ext/types';
-import { SECRET_TYPES } from '@shell/config/secret';
+import { PRODUCT_NAME, PAGE } from '@sbomscanner-ui-ext/types';
 import { filterUnique } from "@sbomscanner-ui-ext/utils/app";
 import { VALID_PLATFORMS, ALLOWED_VARIANTS } from '@sbomscanner-ui-ext/constants/securityConstants';
-import AuthCreateDescription from '@sbomscanner-ui-ext/components/common/AuthCreateDescription.vue';
+import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret.vue';
 
 export default {
   name: 'CruRegistry',
@@ -30,7 +29,7 @@ export default {
     CruResource,
     LabeledSelect,
     Banner,
-    AuthCreateDescription,
+    SelectOrCreateAuthSecret,
   },
 
   mixins: [CreateEditView],
@@ -74,6 +73,7 @@ export default {
       PRODUCT_NAME,
       authLoading:     false,
       osOptions,
+      secretCreateHook: null
     };
   },
 
@@ -85,52 +85,6 @@ export default {
       set(repoStrings){
         this.value.spec.repositories = repoStrings.map((repoName) => ({ name: repoName }));
       },
-    },
-    /**
-     * Build the options list for the authentication dropdown
-     */
-    options() {
-      const headerOptions = [
-        {
-          label: this.t('imageScanner.registries.configuration.cru.authentication.create'),
-          value: 'create',
-          kind:  'highlighted'
-        },
-        {
-          label:    'divider',
-          disabled: true,
-          kind:     'divider'
-        },
-        {
-          label: this.t('generic.none'),
-          value: '',
-        }
-      ];
-
-      if (!this.allSecrets) {
-        return headerOptions;
-      }
-
-      const currentNamespace = this.value.metadata?.namespace ?? 'default';
-
-      const secretOptions = this.allSecrets
-        .filter((secret) => {
-          return secret.metadata.namespace === currentNamespace &&
-                secret._type === SECRET_TYPES.DOCKER_JSON;
-        })
-        .map((secret) => {
-          const name = secret.metadata.name;
-
-          return {
-            label: name,
-            value: name,
-          };
-        });
-
-      return [
-        ...headerOptions,
-        ...secretOptions
-      ];
     },
 
     SCAN_INTERVAL_OPTIONS() {
@@ -177,15 +131,19 @@ export default {
       const requiresRepositories = spec.catalogType === REGISTRY_TYPE.NO_CATALOG;
       const hasRepositories = !requiresRepositories || !!spec.repositories?.length;
 
-      const validSecret = spec.authSecret !== 'create';
-
-      return hasName && hasCatalogType && hasUri && hasRepositories && validSecret;
+      return hasName && hasCatalogType && hasUri && hasRepositories;
     },
 
-    secretCreateUrl() {
-      const clusterId = this.$route.params.cluster;
+    safeRegistryUrl() {
+      const uri = this.value?.spec?.uri || '';
 
-      return `${ LOCAT_HOST.includes(window.location.host) ? '' : '/dashboard' }/c/${ clusterId }/explorer/secret/create?scope=namespaced`;
+      if (!uri) return '';
+
+      if (!/^https?:\/\//i.test(uri)) {
+        return `https://${uri}`;
+      }
+
+      return uri;
     },
   },
 
@@ -195,6 +153,9 @@ export default {
       this.cleanPlatforms();
 
       try {
+        if (this.secretCreateHook) {
+          await this.secretCreateHook();
+        }
         await this.save(event);
       } catch (e) {
         this.errors = [e];
@@ -211,20 +172,8 @@ export default {
       }
     },
 
-    /**
-     * Manually refresh the list of secrets for the dropdown.
-     */
-    async refreshList() {
-      this.authLoading = true;
-      try {
-        this.allSecrets = await this.$store.dispatch(
-          `${ this.inStore }/findAll`, { type: SECRET }
-        );
-      } catch (e) {
-        this.errors = [e];
-      } finally {
-        this.authLoading = false;
-      }
+    registerSecretHook(hookFunction) {
+      this.secretCreateHook = hookFunction;
     },
 
     onFileSelected(value) {
@@ -372,32 +321,24 @@ export default {
       <div class="registry-input-label mt-24">
         {{ t('imageScanner.registries.configuration.cru.authentication.label') }}
       </div>
-      <div class="row">
-        <div class="col span-6">
-          <LabeledSelect
-            v-model:value="value.spec.authSecret"
-            data-testid="auth-secret-select"
-            :label="t('imageScanner.registries.configuration.cru.authentication.label')"
-            :mode="mode"
-            :options="options"
-            :loading="authLoading"
-          />
-        </div>
-      </div>
-      <div
-        v-if="value.spec.authSecret === 'create' "
-        class="row"
-      >
-        <div class="col span-12">
-          <Banner color="info">
-          <AuthCreateDescription
-            :secret-create-url="secretCreateUrl"
-            @refresh="refreshList"
-          />
-          </Banner>
-        </div>
-      </div>
-      <div :class="['registry-input-label', { 'mt-24': value.spec.authSecret !== 'create' }]">
+      <SelectOrCreateAuthSecret
+          data-testid="auth-secret-select"
+          class="auth-secret-override"
+          v-model:value="value.spec.authSecret"
+          :mode="mode"
+          :namespace="value.metadata.namespace || 'default'"
+          :in-store="inStore"
+          :fixed-image-pull-secret="true"
+          :image-pull-secret-docker-json-url-config="safeRegistryUrl"
+          :allow-ssh="false"
+          :allow-basic="false"
+          :allow-s3="false"
+          :allow-rke="false"
+          :register-before-hook="registerSecretHook"
+          generate-name="registry-auth-"
+          :label="t('imageScanner.registries.configuration.cru.authentication.label')"
+      />
+      <div :class="['registry-input-label', 'mt-24']">
         {{ t('imageScanner.registries.configuration.cru.scan.label') }}
       </div>
 
@@ -522,4 +463,9 @@ export default {
   color: var(--input-label);
   font-size: 12px;
 }
+
+.auth-secret-override :deep(.mt-20) {
+  margin-top: 0 !important;
+}
+
 </style>

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
@@ -8,12 +8,12 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
 import Banner from '@components/Banner/Banner.vue';
 import { CATALOG, NAMESPACE, SECRET } from '@shell/config/types';
-import { SECRET_TYPES } from '@shell/config/secret';
 import { SBOMSCANNER_INSTALLATION_NAMESPACE, SCAN_INTERVAL_OPTIONS, SCAN_INTERVALS } from '@sbomscanner-ui-ext/constants';
-import { PRODUCT_NAME, PAGE, LOCAT_HOST } from '@sbomscanner-ui-ext/types';
+import { PRODUCT_NAME, PAGE } from '@sbomscanner-ui-ext/types';
 import { filterUnique } from '@sbomscanner-ui-ext/utils/app';
 import { VALID_PLATFORMS, ALLOWED_VARIANTS, WORKLOAD_SCAN_DOCS_URL } from '@sbomscanner-ui-ext/constants/securityConstants';
 import AuthCreateDescription from '@sbomscanner-ui-ext/components/common/AuthCreateDescription.vue';
+import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret.vue';
 
 const OS_OPTIONS = Object.keys(VALID_PLATFORMS).map((k) => ({ label: k, value: k }));
 
@@ -29,6 +29,7 @@ export default {
     MatchExpressions,
     Banner,
     AuthCreateDescription,
+    SelectOrCreateAuthSecret,
   },
 
   mixins: [CreateEditView],
@@ -63,7 +64,7 @@ export default {
       saveLoading:   false,
       savedEnabledState: true,
       sbomScannerInstallationNamespace: SBOMSCANNER_INSTALLATION_NAMESPACE,
-
+      secretCreateHook: null,
       // Exported constants for the template
       PAGE,
       PRODUCT_NAME,
@@ -128,35 +129,6 @@ export default {
       set(newValue) {
         this.value.spec.scanInterval = newValue;
       }
-    },
-
-    authOptions() {
-      const headerOptions = [
-        { label: this.t('imageScanner.registries.configuration.cru.authentication.create'), value: 'create', kind: 'highlighted' },
-        { label: 'divider', disabled: true, kind: 'divider' },
-        { label: this.t('generic.none'), value: '' }
-      ];
-
-      if (!this.allSecrets) return headerOptions;
-
-      const secretOptions = this.allSecrets
-          .filter((secret) => secret._type === SECRET_TYPES.DOCKER_JSON && secret.metadata.namespace === this.sbomScannerInstallationNamespace)
-          .map((secret) => ({
-            label: `${secret.metadata.name}`,
-            value: secret.metadata.name,
-          }));
-
-      return [...headerOptions, ...secretOptions];
-    },
-
-    validationPassed() {
-      const spec = this.value?.spec || {};
-      return spec.authSecret !== 'create';
-    },
-
-    secretCreateUrl() {
-      const clusterId = this.$route.params.cluster;
-      return `${ LOCAT_HOST.includes(window.location.host) ? '' : '/dashboard' }/c/${ clusterId }/explorer/secret/create?namespace=${this.sbomScannerInstallationNamespace}`;
     },
   },
 
@@ -233,6 +205,10 @@ export default {
       }
     },
 
+    registerSecretHook(hookFunction) {
+      this.secretCreateHook = hookFunction;
+    },
+
     async finish(event) {
       if (event) event.preventDefault();
 
@@ -242,6 +218,9 @@ export default {
       this.cleanBeforeSave();
 
       try {
+        if (this.secretCreateHook) {
+          await this.secretCreateHook();
+        }
         await this.save();
         this.savedEnabledState = this.value.spec.enabled;
 
@@ -303,17 +282,6 @@ export default {
           (p) => p.os && p.arch,
           (p) => `${p.os}-${p.arch}-${p.variant || ''}`
       );
-    },
-
-    async refreshList() {
-      this.authLoading = true;
-      try {
-        this.allSecrets = await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET }, { force: true });
-      } catch (e) {
-        this.errors = [e];
-      } finally {
-        this.authLoading = false;
-      }
     },
 
     onFileSelected(value) {
@@ -382,7 +350,6 @@ export default {
         :resource="value"
         :subtypes="[]"
         :errors="errors"
-        :validation-passed="validationPassed"
         @finish="finish"
         @cancel="done"
     >
@@ -441,17 +408,26 @@ export default {
         {{ t('imageScanner.registries.configuration.cru.authentication.label') }}
       </div>
 
-      <div class="row-half mt-16">
-        <div>
-          <LabeledSelect
+      <div class="row mt-16">
+        <div class="w-half auth-secret-override">
+          <SelectOrCreateAuthSecret
+              data-testid="auth-secret-select"
               v-model:value="value.spec.authSecret"
-              :label="t('imageScanner.registries.configuration.cru.authentication.label')"
               :mode="mode"
-              :options="authOptions"
-              :loading="authLoading"
+              :namespace="sbomScannerInstallationNamespace"
+              :in-store="inStore"
+              :fixed-image-pull-secret="true"
+              image-pull-secret-docker-json-url-config="https://docker.io"
+              :allow-ssh="false"
+              :allow-basic="false"
+              :allow-s3="false"
+              :allow-rke="false"
+              :register-before-hook="registerSecretHook"
+              generate-name="registry-auth-"
+              :label="t('imageScanner.registries.configuration.cru.authentication.label')"
           />
         </div>
-        <div>
+        <div class="col span-6">
           <div class="checkbox-align">
             <Checkbox
                 v-model:value="value.spec.insecure"
@@ -460,17 +436,6 @@ export default {
                 :mode="mode"
             />
           </div>
-        </div>
-      </div>
-
-      <div v-if="value.spec.authSecret === 'create'" class="row mt-16">
-        <div class="col span-12">
-          <Banner color="info" class="m-0">
-            <AuthCreateDescription
-              :secret-create-url="secretCreateUrl"
-              @refresh="refreshList"
-            />
-          </Banner>
         </div>
       </div>
 
@@ -565,7 +530,7 @@ export default {
           <button
               type="button"
               class="btn role-primary"
-              :disabled="!validationPassed || saveLoading"
+              :disabled="saveLoading"
               @click="finish"
           >
             {{ isCreate ? t('generic.create') : t('generic.save') }}
@@ -605,6 +570,22 @@ export default {
 
   .platform-add-row {
     width: $span-10-width;
+  }
+
+  .auth-secret-override {
+    margin-right: 16px;
+    :deep(.select-or-create-auth-secret > .mt-20) {
+      margin-top: 0 !important;
+    }
+
+    :deep(.select-or-create-auth-secret > .row > .col) {
+      flex: 1 1 100%;
+      max-width: 100%;
+      margin-bottom: 12px;
+    }
+    :deep(.select-or-create-auth-secret > .row > .col:last-child) {
+      margin-bottom: 0;
+    }
   }
 
   /* ---- Match Expressions Grid Override ---- */


### PR DESCRIPTION
## Description

Fix #540 

Refactors the Authentication Secret selection process in the **Registry** and **Workload Scan Configuration** creation/edit pages to use standard Rancher components.

**Key Changes:**
Replaced the manual `LabeledSelect` dropdown and custom secret creation logic with the standard Rancher `@shell/components/form/SelectOrCreateAuthSecret.vue` component.

<img width="1426" height="587" alt="Screenshot 2026-04-15 at 7 05 40 PM" src="https://github.com/user-attachments/assets/857b2483-244c-4ca4-9218-0d4a60376c3f" />
<img width="1446" height="778" alt="Screenshot 2026-04-15 at 7 14 11 PM" src="https://github.com/user-attachments/assets/a38d5a0e-0b89-4194-9552-f64ebde22721" />
<img width="1470" height="848" alt="Screenshot 2026-04-15 at 7 06 08 PM" src="https://github.com/user-attachments/assets/78003896-e695-499e-8e15-8bb44a1fa86d" />


## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
