### PR TITLE
[bugfix] Scanning setting to manual does not work

### DIFF
--- a/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
+++ b/pkg/sbomscanner-ui-ext/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
@@ -107,6 +107,21 @@ describe('CruWorkloadScanConfiguration.vue', () => {
   afterEach(() => { jest.clearAllMocks(); });
 
   describe('Initialization and State', () => {
+    it('sets default scanInterval to THREE_HOURS when creating a new configuration', () => {
+      wrapper = createWrapper({}, 'create', {});
+      wrapper.vm.initDefaults();
+      expect(wrapper.vm.value.spec.scanInterval).toBe(SCAN_INTERVALS.THREE_HOURS);
+    });
+
+    it('does not overwrite missing scanInterval (Manual mode) when editing an existing configuration', () => {
+      const existingConfig = { metadata: { name: 'default' }, spec: { enabled: true } };
+      wrapper = createWrapper({}, 'edit', existingConfig);
+
+      wrapper.vm.initDefaults();
+
+      expect(wrapper.vm.value.spec.scanInterval).toBeUndefined();
+    });
+
     it('renders correctly and captures initial savedEnabledState', () => {
       wrapper = createWrapper({ enabled: true });
       expect(wrapper.exists()).toBe(true);

--- a/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
+++ b/pkg/sbomscanner-ui-ext/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
@@ -185,8 +185,11 @@ export default {
         caBundle:           '',
         insecure:           false,
         platforms:          [],
-        scanInterval:       SCAN_INTERVALS.THREE_HOURS,
       };
+
+      if (this.isCreate) {
+        defaultSpec.scanInterval = SCAN_INTERVALS.THREE_HOURS;
+      }
 
       for (const [key, val] of Object.entries(defaultSpec)) {
         if (this.value.spec[key] === undefined) {


### PR DESCRIPTION
## Description

Fix #547 

This PR fixes a bug where the Workload Scan Configuration's `scanInterval` dropdown would incorrectly revert to "Every 3 hours" when editing a configuration that was previously saved as "Manual". 

**The fix:**
Updated `initDefaults()` so that the `SCAN_INTERVALS.THREE_HOURS` default is only applied when creating a brand *new* configuration.

## Test

To test this pull request, you can follow these steps:

**Manual UI Testing:**
1. Navigate to the Workload Scan Configuration page and create or edit a configuration.
2. Change the "Scan Interval" dropdown to **Manual**.
3. Click **Save**.
4. edit it again.
5. **Verify:** The Scan Interval dropdown should still display **Manual**.

<img width="1894" height="838" alt="Screenshot 2026-04-21 at 10 41 50 AM" src="https://github.com/user-attachments/assets/f64ef2b0-ad48-4ed0-a7fb-509b59a1f6e3" />
