### PR TITLE
[Enh] Add expandable truncation for long description

### DIFF
--- a/pkg/sbomscanner-ui-ext/components/CveDetails.vue
+++ b/pkg/sbomscanner-ui-ext/components/CveDetails.vue
@@ -4,10 +4,11 @@ import { BadgeState } from '@components/BadgeState';
 import { PRODUCT_NAME, RESOURCE, PAGE } from '@sbomscanner-ui-ext/types';
 import { NVD_BASE_URL, CVSS_VECTOR_BASE_URL } from '@sbomscanner-ui-ext/constants';
 import { getHighestScore } from '@sbomscanner-ui-ext/utils/report';
+import ExpandableDescription from "@sbomscanner-ui-ext/components/common/ExpandableDescription.vue";
 
 export default {
   name:       'CveDetails',
-  components: { BadgeState },
+  components: { BadgeState, ExpandableDescription },
   data() {
     return {
       PRODUCT_NAME,
@@ -52,7 +53,7 @@ export default {
                   sources:         hasCvss ? this.convertCvssToSources(vuln.cvss, cveId) : [],
                   severity:        vuln.severity,
                   cvssScores:      hasCvss ? this.convertCvss(vuln.cvss) : [],
-                  title:           vuln.title,
+                  description:     vuln.description,
                   advisoryVendors: this.groupReferencesByDomain(vuln.references),
                 };
               }
@@ -176,7 +177,10 @@ export default {
         </div>
       </div>
       <!--    description -->
-      <span class="description">{{ cveDetail?.title || t('imageScanner.general.unknown') }}</span>
+      <ExpandableDescription
+          :text="cveDetail?.description || t('imageScanner.general.unknown')"
+          :lines="3" />
+
       <!--  meta data  -->
       <div class="stats">
         <div class="column column-1">
@@ -333,15 +337,6 @@ export default {
     width: 225px;
     height: 40px;
   }
-}
-
-.description {
-  display: block;
-  color: var(--disabled-text);
-  font-family: Lato;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 21px;
 }
 
 .stats {

--- a/pkg/sbomscanner-ui-ext/components/RegistryDetails.vue
+++ b/pkg/sbomscanner-ui-ext/components/RegistryDetails.vue
@@ -22,11 +22,11 @@
               :status="registry?.scanRec.currStatus"
             />
           </h1>
-          <span
+          <ExpandableDescription
               v-if="registry?.description"
-              class="resource-header-description">
-            {{  registry.description }}
-          </span>
+              :text="registry.description"
+              :lines="3"
+          />
         </div>
         <div class="resource-header-actions">
           <ScanButton
@@ -63,6 +63,7 @@ import RegistryDetailScanTable from './RegistryDetailScanTable.vue';
 import ScanButton from './common/ScanButton.vue';
 import { getPermissions } from '@sbomscanner-ui-ext/utils/permissions';
 import { trimIntervalSuffix } from '@sbomscanner-ui-ext/utils/app';
+import ExpandableDescription from './common/ExpandableDescription.vue';
 
 export default {
   name:       'RegistryDetails',
@@ -73,6 +74,7 @@ export default {
     ScanButton,
     ActionMenu,
     Loading,
+    ExpandableDescription,
   },
   data() {
     return {

--- a/pkg/sbomscanner-ui-ext/components/__tests__/CveDetails.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/__tests__/CveDetails.spec.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import { shallowMount, flushPromises } from '@vue/test-utils';
 import CveDetails from '../CveDetails.vue';
 import { BadgeState } from '@components/BadgeState';
+import ExpandableDescription from '../common/ExpandableDescription.vue';
 import { RESOURCE } from '@sbomscanner-ui-ext/types';
 import { NVD_BASE_URL, CVSS_VECTOR_BASE_URL } from '@sbomscanner-ui-ext/constants';
 
@@ -24,16 +25,16 @@ const mockVulReports = [
         {
           vulnerabilities: [
             {
-              cve:        'CVE-2023-9999',
-              severity:   'Low',
-              title:      'Another vulnerability',
-              references: [],
-              cvss:       {}
+              cve:         'CVE-2023-9999',
+              severity:    'Low',
+              description: 'Another vulnerability description',
+              references:  [],
+              cvss:        {}
             },
             {
-              cve:        mockCveId,
-              severity:   'Critical',
-              title:      'A very bad vulnerability',
+              cve:         mockCveId,
+              severity:    'Critical',
+              description: 'A very bad vulnerability description',
               references: [
                 'https://suse.com/security/cve/CVE-2023-1234',
                 'https://www.redhat.com/en/blog/press-release',
@@ -62,9 +63,9 @@ const mockVulReports = [
         {
           vulnerabilities: [
             {
-              cve:      mockCveId,
-              severity: 'Critical',
-              title:    'A very bad vulnerability',
+              cve:         mockCveId,
+              severity:    'Critical',
+              description: 'A very bad vulnerability description',
             }
           ]
         }
@@ -85,14 +86,14 @@ describe('CveDetails.vue', () => {
   const createWrapper = (store = mockStore, route = mockRoute) => {
     return shallowMount(CveDetails, {
       global: {
-        components: { BadgeState },
+        components: { BadgeState, ExpandableDescription },
         mocks:      {
           $store: store,
           $route: route,
           t:      mockT,
         }
       },
-      stubs: { BadgeState: true }
+      stubs: { BadgeState: true, ExpandableDescription: true }
     });
   };
 
@@ -165,7 +166,9 @@ describe('CveDetails.vue', () => {
       expect(totalScanned).toBe(2);
       expect(cveMetaData.score).toBe('9.8 (v3)');
       expect(cveMetaData.severity).toBe('Critical');
-      expect(cveMetaData.title).toBe('A very bad vulnerability');
+
+      expect(cveMetaData.description).toBe('A very bad vulnerability description');
+
       expect(cveMetaData.sources).toEqual([
         { name: 'NVD', link: `${ NVD_BASE_URL }${ mockCveId }` },
         { name: 'REDHAT', link: '' },
@@ -209,26 +212,23 @@ describe('CveDetails.vue', () => {
       await flushPromises();
 
       const title = wrapper.find('.resource-header-name');
-
       expect(title.text()).toContain(`imageScanner.vulnerabilities.title: ${ mockCveId }`);
 
-      const description = wrapper.find('.description');
-
-      expect(description.text()).toBe('A very bad vulnerability');
+      const description = wrapper.findComponent(ExpandableDescription);
+      expect(description.exists()).toBe(true);
+      expect(description.props('text')).toBe('A very bad vulnerability description');
+      expect(description.props('lines')).toBe(3);
 
       const statItems = wrapper.findAll('.stat-item');
-
       expect(statItems[0].text()).toContain('imageScanner.vulnerabilities.details.score9.8 (v3)');
       expect(statItems[1].text()).toContain('imageScanner.vulnerabilities.details.imageIdentifiedIn2');
 
       const sourceLinks = wrapper.findAll('.source-link');
-
       expect(sourceLinks.length).toBe(1);
       expect(sourceLinks[0].attributes('href')).toBe(`${ NVD_BASE_URL }${ mockCveId }`);
       expect(sourceLinks[0].text()).toContain('NVD');
 
       const cvssLinks = wrapper.findAll('.cvss-link');
-
       expect(cvssLinks.length).toBe(3);
       expect(cvssLinks[0].text()).toContain('Nvd v3score 9.8');
       expect(cvssLinks[0].attributes('href')).toContain('CVSS:3.1');
@@ -240,16 +240,14 @@ describe('CveDetails.vue', () => {
       wrapper = createWrapper(mockStore, route);
       await flushPromises();
 
-      expect(wrapper.vm.cveDetail.title).toBeUndefined();
+      expect(wrapper.vm.cveDetail.description).toBeUndefined();
       expect(wrapper.vm.cveDetail.score).toBeUndefined();
       expect(wrapper.vm.cveDetail.totalImages).toBe(2);
 
-      const description = wrapper.find('.description');
-
-      expect(description.text()).toBe('imageScanner.general.unknown');
+      const description = wrapper.findComponent(ExpandableDescription);
+      expect(description.props('text')).toBe('imageScanner.general.unknown');
 
       const statItems = wrapper.findAll('.stat-item');
-
       expect(statItems[0].text()).toContain('imageScanner.vulnerabilities.details.scoreimageScanner.general.unknown');
     });
   });

--- a/pkg/sbomscanner-ui-ext/components/__tests__/RegistryDetails.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/__tests__/RegistryDetails.spec.ts
@@ -4,6 +4,7 @@ import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import StatusBadge from '../common/StatusBadge.vue';
 import RegistryDetailScanTable from '../RegistryDetailScanTable.vue';
 import ScanButton from '../common/ScanButton.vue';
+import ExpandableDescription from '../common/ExpandableDescription.vue';
 import { trimIntervalSuffix } from '@sbomscanner-ui-ext/utils/app';
 
 jest.mock('../common/RegistryDetailsMeta.vue', () => ({
@@ -32,8 +33,9 @@ describe('RegistryDetails.vue', () => {
   const mockRouter = { push: jest.fn() };
 
   const registryMock = {
-    metadata: { name: 'my-reg', namespace: 'ns1' },
-    spec:     {
+    metadata:    { name: 'my-reg', namespace: 'ns1' },
+    description: 'A test description for the registry', // <-- Added description to mock
+    spec:        {
       uri:          'http://test.registry',
       repositories: [{ name: 'repo1' }, { name: 'repo2' }],
       scanInterval: '5m',
@@ -92,7 +94,7 @@ describe('RegistryDetails.vue', () => {
           $fetchState: { pending: false },
           $route:      {
             params: {
-              cluster: 'local', id: 'my-reg', ns: 'ns1'
+              cluster: 'local', id: 'my-reg', namespace: 'ns1'
             }
           },
           $router: mockRouter,
@@ -105,6 +107,7 @@ describe('RegistryDetails.vue', () => {
           RegistryDetailScanTable: true,
           RegistryDetailsMeta:     true,
           ScanButton:              true,
+          ExpandableDescription:   true, // <-- Stubbed the new component
         },
       },
       ...options,
@@ -166,7 +169,7 @@ describe('RegistryDetails.vue', () => {
     expect(wrapper.findComponent(ActionMenu).exists()).toBe(true);
   });
 
-  it('renders child components', async() => {
+  it('renders child components including ExpandableDescription', async() => {
     const wrapper = factory({ reg: registryMock, scanjob: scanJobsMock });
 
     await wrapper.vm.loadData();
@@ -174,6 +177,19 @@ describe('RegistryDetails.vue', () => {
     expect(wrapper.findComponent(StatusBadge).exists()).toBe(true);
     expect(wrapper.findComponent(RegistryDetailScanTable).exists()).toBe(true);
     expect(wrapper.findComponent(ScanButton).exists()).toBe(true);
+
+    const expandableDesc = wrapper.findComponent(ExpandableDescription);
+    expect(expandableDesc.exists()).toBe(true);
+    expect(expandableDesc.props('text')).toBe('A test description for the registry');
+    expect(expandableDesc.props('lines')).toBe(3);
+  });
+
+  it('does not render ExpandableDescription when registry has no description', async() => {
+    const wrapper = factory({ reg: registryMockNoImages, scanjob: scanJobsMock });
+
+    await wrapper.vm.loadData();
+
+    expect(wrapper.findComponent(ExpandableDescription).exists()).toBe(false);
   });
 
   it('handles empty repositories & scanInterval gracefully', async() => {

--- a/pkg/sbomscanner-ui-ext/components/common/ExpandableDescription.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/ExpandableDescription.vue
@@ -1,0 +1,120 @@
+<script>
+export default {
+  name: 'ExpandableDescription',
+  props: {
+    text: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    lines: {
+      type: Number,
+      default: 3
+    }
+  },
+  data() {
+    return {
+      isExpanded: false,
+      isTruncatable: false,
+    };
+  },
+  watch: {
+    text() {
+      this.checkTruncation();
+    }
+  },
+  mounted() {
+    this.checkTruncation();
+    window.addEventListener('resize', this.checkTruncation);
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.checkTruncation);
+  },
+  methods: {
+    checkTruncation() {
+      this.$nextTick(() => {
+        const el = this.$refs.content;
+        if (!el) return;
+
+        // If the total scrollable height is greater than the clamped visible height,
+        // it means the text exceeds the 3-line limit.
+        this.isTruncatable = el.scrollHeight > el.clientHeight;
+      });
+    },
+    expand() {
+      this.isExpanded = true;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="expandable-description">
+    <div
+        ref="content"
+        class="content-text"
+        :class="{ 'clamped': !isExpanded, 'expanded': isExpanded }"
+        :style="{ '--line-clamp': lines }"
+    >
+      {{ text }}
+    </div>
+
+    <span
+        v-if="!isExpanded && isTruncatable"
+        class="read-more-btn"
+        @click="expand"
+    >
+      {{ t('imageScanner.general.readMore') }}
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.expandable-description {
+  position: relative;
+  width: 100%;
+  display: block;
+}
+
+.content-text {
+  color: var(--disabled-text);
+  font-family: 'Lato', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+
+  /* Smooth slide-down transition */
+  transition: max-height 0.4s ease-in-out;
+  overflow: hidden;
+
+  &.clamped {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--line-clamp, 3);
+    /* Calculate exact max-height: 21px line-height * 3 lines */
+    max-height: calc(21px * var(--line-clamp, 3));
+  }
+
+  &.expanded {
+    /* Arbitrarily large max-height to allow the slide-down transition to complete */
+    max-height: 2000px;
+  }
+}
+
+.read-more-btn {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  color: var(--disabled-text);
+  text-decoration: underline;
+  cursor: pointer;
+
+  /* Use a gradient to fade over the text smoothly, hiding the native CSS ellipsis */
+  background: linear-gradient(to right, transparent, var(--body-bg) 24px, var(--body-bg) 100%);
+  padding-left: 24px;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+</style>

--- a/pkg/sbomscanner-ui-ext/components/common/RegistryDetailsMeta.vue
+++ b/pkg/sbomscanner-ui-ext/components/common/RegistryDetailsMeta.vue
@@ -81,7 +81,6 @@ export default {
   row-gap: 4px;
   column-gap: 24px;
   align-self: stretch;
-  margin-top: 16px;
 }
 
 .stat-item {

--- a/pkg/sbomscanner-ui-ext/components/common/__tests__/ExpandableDescription.spec.ts
+++ b/pkg/sbomscanner-ui-ext/components/common/__tests__/ExpandableDescription.spec.ts
@@ -1,0 +1,137 @@
+import { shallowMount } from '@vue/test-utils';
+import ExpandableDescription from '../ExpandableDescription.vue';
+
+describe('ExpandableDescription.vue', () => {
+  let wrapper;
+
+  const createWrapper = (props = {}) => {
+    return shallowMount(ExpandableDescription, {
+      props: {
+        text: 'Default testing text',
+        ...props
+      },
+      global: {
+        mocks: {
+          t: (key) => key
+        }
+      }
+    });
+  };
+
+  const mockDimensions = (contentRef, scrollHeight, clientHeight) => {
+    Object.defineProperty(contentRef, 'scrollHeight', { value: scrollHeight, configurable: true });
+    Object.defineProperty(contentRef, 'clientHeight', { value: clientHeight, configurable: true });
+  };
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering and Default State', () => {
+    it('renders the provided text', () => {
+      wrapper = createWrapper({ text: 'Hello World' });
+      const content = wrapper.find('.content-text');
+      expect(content.text()).toBe('Hello World');
+    });
+
+    it('applies the clamped class by default', () => {
+      wrapper = createWrapper();
+      const content = wrapper.find('.content-text');
+      expect(content.classes()).toContain('clamped');
+      expect(content.classes()).not.toContain('expanded');
+    });
+
+    it('sets the correct CSS variable for line clamps', () => {
+      wrapper = createWrapper({ lines: 5 });
+      const content = wrapper.find('.content-text');
+      expect(content.attributes('style')).toContain('--line-clamp: 5');
+    });
+  });
+
+  describe('Truncation Logic', () => {
+    it('shows the "read more" button when scrollHeight is greater than clientHeight', async () => {
+      wrapper = createWrapper();
+
+      mockDimensions(wrapper.vm.$refs.content, 100, 60);
+
+      wrapper.vm.checkTruncation();
+
+      // We need TWO nextTicks:
+      // 1st evaluates the height inside checkTruncation's inner $nextTick
+      // 2nd allows Vue to actually update the DOM with the new button
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isTruncatable).toBe(true);
+      expect(wrapper.find('.read-more-btn').exists()).toBe(true);
+      expect(wrapper.find('.read-more-btn').text()).toBe('imageScanner.general.readMore');
+    });
+
+    it('hides the "read more" button when text fits perfectly', async () => {
+      wrapper = createWrapper();
+
+      mockDimensions(wrapper.vm.$refs.content, 40, 40);
+
+      wrapper.vm.checkTruncation();
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isTruncatable).toBe(false);
+      expect(wrapper.find('.read-more-btn').exists()).toBe(false);
+    });
+  });
+
+  describe('User Interaction', () => {
+    it('expands the text and hides the button when "read more" is clicked', async () => {
+      wrapper = createWrapper();
+
+      // Force it to be truncatable first so the button renders
+      mockDimensions(wrapper.vm.$refs.content, 100, 60);
+      wrapper.vm.checkTruncation();
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      // Ensure button is there, then click it
+      const btn = wrapper.find('.read-more-btn');
+      expect(btn.exists()).toBe(true);
+      await btn.trigger('click');
+
+      // Verify the state changes
+      expect(wrapper.vm.isExpanded).toBe(true);
+      expect(wrapper.find('.content-text').classes()).toContain('expanded');
+      expect(wrapper.find('.content-text').classes()).not.toContain('clamped');
+
+      // The button should disappear after expanding
+      expect(wrapper.find('.read-more-btn').exists()).toBe(false);
+    });
+  });
+
+  describe('Watchers and Lifecycle Hooks', () => {
+    it('re-evaluates truncation when the text prop changes', async () => {
+      wrapper = createWrapper();
+      const checkSpy = jest.spyOn(wrapper.vm, 'checkTruncation');
+
+      await wrapper.setProps({ text: 'A completely new, much longer description string.' });
+
+      expect(checkSpy).toHaveBeenCalled();
+    });
+
+    it('attaches and removes window resize listeners', () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+      wrapper = createWrapper();
+
+      // Listener should be added on mount
+      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', wrapper.vm.checkTruncation);
+
+      wrapper.unmount(); // Updated to unmount()
+
+      // Listener should be cleaned up on destroy
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', wrapper.vm.checkTruncation);
+    });
+  });
+});

--- a/pkg/sbomscanner-ui-ext/detail/__tests__/sbomscanner.kubewarden.io.vexhub.spec.ts
+++ b/pkg/sbomscanner-ui-ext/detail/__tests__/sbomscanner.kubewarden.io.vexhub.spec.ts
@@ -1,0 +1,212 @@
+import { mount } from '@vue/test-utils';
+import { jest } from '@jest/globals';
+import VexHub from '../sbomscanner.kubewarden.io.vexhub.vue'; // Adjust path as needed
+import { useStore } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
+
+// 1. Mock Vuex safely
+jest.mock('vuex', () => ({
+  useStore: jest.fn(),
+  mapGetters: jest.fn(),
+  mapState: jest.fn()
+}));
+
+jest.mock('@shell/composables/useI18n', () => ({
+  useI18n: jest.fn()
+}));
+
+// 2. Mock heavy Rancher @shell components at the module level
+// to bypass deep import compilation errors and warnings!
+jest.mock('@shell/components/Resource/Detail/Page.vue', () => ({
+  default: {
+    name: 'DetailPage',
+    template: '<div class="detail-page-stub"><slot name="top-area" /></div>'
+  }
+}));
+
+jest.mock('@shell/components/Resource/Detail/TitleBar/index.vue', () => ({
+  default: {
+    name: 'TitleBar',
+    template: '<div class="title-bar-stub"><slot name="additional-actions" /></div>',
+    props: ['resource', 'resourceName', 'resourceTypeLabel', 'resourceTo', 'badge', 'actionMenuResource', 'showViewOptions']
+  }
+}));
+
+jest.mock('@shell/components/Resource/Detail/Metadata/index.vue', () => ({
+  default: {
+    name: 'Metadata',
+    template: '<div class="metadata-stub"></div>',
+    props: ['resource', 'identifyingInformation', 'annotations', 'labels']
+  }
+}));
+
+jest.mock('@shell/components/formatter/Date.vue', () => ({
+  default: { name: 'DateFormatter', template: '<span></span>' }
+}));
+
+describe('vexhub.vue', () => {
+  let mockStore;
+  let mockT;
+
+  beforeEach(() => {
+    mockStore = {
+      getters: {},
+      dispatch: jest.fn()
+    };
+    (useStore as jest.Mock).mockReturnValue(mockStore);
+
+    // Mock translation function to return the key
+    mockT = jest.fn((key) => key);
+    (useI18n as jest.Mock).mockReturnValue({ t: mockT });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createWrapper = (propsValue = {}) => {
+    return mount(VexHub, {
+      props: {
+        value: propsValue
+      },
+      global: {
+        stubs: {
+          // We only need to stub our own custom components here now
+          ExpandableDescription: { template: '<div class="expandable-description-stub"></div>', props: ['text', 'lines'] }
+        }
+      }
+    });
+  };
+
+  const baseVexHubValue = {
+    metadata: {
+      name: 'demo-vexhub',
+      generation: 1,
+      creationTimestamp: '2026-04-23T11:29:57Z'
+    },
+    spec: {
+      enabled: true,
+      url: 'http://test.com'
+    },
+    description: 'This is a test description for the vexhub.',
+    listLocation: { name: 'vex-list-route' },
+    toggle: {
+      label: 'Disable',
+      icon: 'icon-pause',
+      invoke: jest.fn()
+    }
+  };
+
+  describe('Component Rendering & Layout', () => {
+    it('renders the core layout components', () => {
+      const wrapper = createWrapper(baseVexHubValue);
+
+      expect(wrapper.find('.detail-page-stub').exists()).toBe(true);
+      expect(wrapper.find('.title-bar-stub').exists()).toBe(true);
+      expect(wrapper.find('.metadata-stub').exists()).toBe(true);
+      expect(wrapper.find('.expandable-description-stub').exists()).toBe(true);
+    });
+
+    it('hides the ExpandableDescription if no description is provided', () => {
+      const noDescValue = { ...baseVexHubValue, description: undefined };
+      const wrapper = createWrapper(noDescValue);
+
+      expect(wrapper.find('.expandable-description-stub').exists()).toBe(false);
+    });
+  });
+
+  describe('Computed: defaultMastheadProps', () => {
+    it('computes titleBarProps correctly when enabled', () => {
+      const wrapper = createWrapper(baseVexHubValue);
+      const titleBar = wrapper.findComponent('.title-bar-stub');
+
+      expect(titleBar.props('resource')).toEqual(baseVexHubValue);
+      expect(titleBar.props('resourceName')).toBe('demo-vexhub');
+      expect(titleBar.props('resourceTypeLabel')).toBe('imageScanner.vexManagement.title');
+      expect(titleBar.props('resourceTo')).toEqual({ name: 'vex-list-route' });
+      expect(titleBar.props('showViewOptions')).toBe(false);
+
+      // Check Badge
+      expect(titleBar.props('badge')).toEqual({
+        color: 'bg-success',
+        label: 'imageScanner.enum.status.enabled'
+      });
+    });
+
+    it('computes titleBarProps correctly when disabled', () => {
+      const disabledValue = { ...baseVexHubValue, spec: { ...baseVexHubValue.spec, enabled: false } };
+      const wrapper = createWrapper(disabledValue);
+      const titleBar = wrapper.findComponent('.title-bar-stub');
+
+      expect(titleBar.props('badge')).toEqual({
+        color: 'bg-error',
+        label: 'imageScanner.enum.status.disabled'
+      });
+    });
+
+    it('computes metadataProps correctly for generation 1 (Rancher)', () => {
+      const wrapper = createWrapper(baseVexHubValue);
+      const metadata = wrapper.findComponent('.metadata-stub');
+      const identifyingInfo = metadata.props('identifyingInformation');
+
+      expect(identifyingInfo).toHaveLength(4);
+
+      // URI
+      expect(identifyingInfo[0].label).toBe('URI');
+      expect(identifyingInfo[0].value).toBe('http://test.com');
+
+      // Created by (Generation 1 = Rancher)
+      expect(identifyingInfo[1].label).toBe('Created by');
+      expect(identifyingInfo[1].value).toBe('Rancher');
+
+      // Last sync
+      expect(identifyingInfo[2].label).toBe('Last sync');
+      expect(identifyingInfo[2].value).toBeUndefined();
+
+      // Updated
+      expect(identifyingInfo[3].label).toBe('Updated');
+      expect(identifyingInfo[3].value).toBe('2026-04-23T11:29:57Z');
+    });
+
+    it('computes metadataProps correctly for generation > 1 (Manual entry)', () => {
+      const manualValue = { ...baseVexHubValue, metadata: { ...baseVexHubValue.metadata, generation: 2 } };
+      const wrapper = createWrapper(manualValue);
+      const metadata = wrapper.findComponent('.metadata-stub');
+      const identifyingInfo = metadata.props('identifyingInformation');
+
+      // Created by (Generation != 1 = Manual entry)
+      expect(identifyingInfo[1].label).toBe('Created by');
+      expect(identifyingInfo[1].value).toBe('Manual entry');
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('renders the toggle button with correct label and icon if value.toggle exists', () => {
+      const wrapper = createWrapper(baseVexHubValue);
+      const button = wrapper.find('[data-testid="detail-explore-button"]');
+
+      expect(button.exists()).toBe(true);
+      expect(button.text()).toContain('Disable');
+      expect(button.find('i').classes()).toContain('icon-pause');
+    });
+
+    it('invokes the toggle function when the action button is clicked', async () => {
+      const invokeMock = jest.fn();
+      const val = { ...baseVexHubValue, toggle: { label: 'Enable', icon: 'icon-play', invoke: invokeMock } };
+      const wrapper = createWrapper(val);
+      const button = wrapper.find('[data-testid="detail-explore-button"]');
+
+      await button.trigger('click');
+
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the toggle button if value.toggle is missing', () => {
+      const noToggleValue = { ...baseVexHubValue, toggle: undefined };
+      const wrapper = createWrapper(noToggleValue);
+      const button = wrapper.find('[data-testid="detail-explore-button"]');
+
+      expect(button.exists()).toBe(false);
+    });
+  });
+});

--- a/pkg/sbomscanner-ui-ext/detail/sbomscanner.kubewarden.io.vexhub.vue
+++ b/pkg/sbomscanner-ui-ext/detail/sbomscanner.kubewarden.io.vexhub.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
-import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
+import TitleBar from '@shell/components/Resource/Detail/TitleBar/index.vue';
+import Metadata from '@shell/components/Resource/Detail/Metadata/index.vue';
 import Date from '@shell/components/formatter/Date.vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import UriExternalLink from '@sbomscanner-ui-ext/formatters/UriExternalLink.vue';
+import ExpandableDescription from '@sbomscanner-ui-ext/components/common/ExpandableDescription.vue';
 import { computed } from 'vue';
 
 const store = useStore();
@@ -22,7 +24,6 @@ const defaultMastheadProps = computed(() => {
       resourceName:      vexhub?.metadata?.name ?? '',
       resourceTypeLabel: t('imageScanner.vexManagement.title'),
       resourceTo:        vexhub?.listLocation,
-      description:       vexhub?.description ?? '',
       badge:             {
         color: vexhub?.spec?.enabled ? ('bg-success' as 'bg-success') : ('bg-error' as 'bg-error'),
         label: t(`imageScanner.enum.status.${vexhub?.spec?.enabled ? 'enabled' : 'disabled'}`)
@@ -68,7 +69,8 @@ const defaultMastheadProps = computed(() => {
 <template>
   <DetailPage>
     <template #top-area>
-      <Masthead class="masthead" v-bind="defaultMastheadProps">
+
+      <TitleBar v-bind="defaultMastheadProps.titleBarProps">
         <template #additional-actions>
           <button
               v-if="value?.toggle"
@@ -81,7 +83,22 @@ const defaultMastheadProps = computed(() => {
             {{ value.toggle.label }}
           </button>
         </template>
-      </Masthead>
+      </TitleBar>
+
+      <ExpandableDescription
+          v-if="vexhub?.description"
+          :text="vexhub.description"
+          :lines="3"
+          class="vex-description"
+      />
+
+      <div class="metadata-wrapper">
+        <Metadata
+            class="masthead"
+            v-bind="defaultMastheadProps.metadataProps"
+        />
+      </div>
+
     </template>
   </DetailPage>
 </template>
@@ -89,6 +106,17 @@ const defaultMastheadProps = computed(() => {
 <style lang="scss" scoped>
 .btn.actions {
   gap: 12px;
+}
+
+.vex-description {
+  max-width: calc(100% - 350px);
+  margin-top: 4px;
+  margin-bottom: 24px;
+}
+
+.metadata-wrapper {
+  margin-top: 16px;
+  margin-bottom: 24px;
 }
 
 /* Hide empty labels and annotations section */

--- a/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
+++ b/pkg/sbomscanner-ui-ext/l10n/en-us.yaml
@@ -447,6 +447,7 @@ imageScanner:
     unknown: Unknown
     noActions: No actions
     learnMore: Learn more
+    readMore: ... read more
     saved: Saved
     active: Active
     inactive: Inactive


### PR DESCRIPTION
## Description

Fix #556 

**What changed:**
This PR introduces a new standard UI component to handle long descriptions

* **Added `ExpandableDescription.vue`:** A reusable component that truncates text if it exceeds 3 lines. It appends a inline "... read more" button that, when clicked, reveals the full text using a slide-down CSS transition.
* **Updated `CveDetails.vue`:** Replaced the static description `<span>` with the new `<ExpandableDescription>` component.

## Test

1. Navigate to the Vulnerabilities section and click on a CVE that has a long description (more than 3 lines of text).
2. **Verify:** The text should truncate at 3 lines, ending with a secondary `... read more` link.
3. Hover over the `... read more` link to verify the underline disappears.
4. Click `... read more`. 
5. **Verify:** The link should disappear, and the text should expand to show the full description, pushing the stats grid below it downward.

<img width="1349" height="584" alt="Screenshot 2026-04-23 at 10 19 57 AM" src="https://github.com/user-attachments/assets/690e15aa-8cf9-4d95-bb9d-4a740feef8ea" />

Clicked the "... read more"

<img width="1363" height="554" alt="Screenshot 2026-04-23 at 10 20 25 AM" src="https://github.com/user-attachments/assets/0375a8a1-b5be-45f2-9f00-1636dba28513" />

Vexhub detail page:

<img width="1350" height="509" alt="Screenshot 2026-04-23 at 11 14 44 PM" src="https://github.com/user-attachments/assets/86971c53-943a-4030-bbcf-9b5fbc9522a6" />

Registry detail page:

<img width="1351" height="758" alt="Screenshot 2026-04-23 at 12 06 54 PM" src="https://github.com/user-attachments/assets/d7a68a58-b1e7-4a93-adf6-25db12c71845" />

